### PR TITLE
Fix aircraft detail

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -148,8 +148,18 @@ String directionAsString(double? direction) {
 }
 
 String getAltitudeAsString(double? altitude) {
-  if (altitude == null || altitude == -1000) return 'Unknown';
+  if (altitude == null || altitude == INV_ALT) return 'Unknown';
   return sprintf('%3.1f m', [altitude]);
+}
+
+String getSpeedVertAsString(double? speed) {
+  if (speed == null || speed == INV_SPEED_V) return 'Unknown';
+  return sprintf('%3.2f m/s', [speed]);
+}
+
+String getSpeedHorAsString(double? speed) {
+  if (speed == null || speed == INV_SPEED_H) return 'Unknown';
+  return sprintf('%3.2f m/s', [speed]);
 }
 
 Widget? getFlag(String countryCode) {

--- a/lib/widgets/sliders/aircraft/detail/location_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/location_fields.dart
@@ -169,7 +169,7 @@ class LocationFields {
           if (loc != null && loc.height != null)
             AircraftDetailField(
               headlineText: 'Height',
-              fieldText: '${loc.height} m',
+              fieldText: getAltitudeAsString(loc.height),
             ),
           if (loc != null && loc.heightType != null)
             AircraftDetailField(
@@ -193,15 +193,14 @@ class LocationFields {
       ),
       AircraftDetailRow(
         children: [
-          if (loc != null && loc.speedHorizontal != null)
+          if (loc != null)
             AircraftDetailField(
-              headlineText: 'Horizontal Speed',
-              fieldText: '${loc.speedHorizontal} m/s',
-            ),
-          if (loc != null && loc.speedVertical != null)
+                headlineText: 'Horizontal Speed',
+                fieldText: getSpeedHorAsString(loc.speedHorizontal)),
+          if (loc != null)
             AircraftDetailField(
               headlineText: 'Vertical Speed',
-              fieldText: '${loc.speedVertical} m/s',
+              fieldText: getSpeedVertAsString(loc.speedVertical),
             ),
         ],
       ),

--- a/lib/widgets/sliders/aircraft/detail/location_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/location_fields.dart
@@ -100,9 +100,12 @@ class LocationFields {
                       size: 20,
                     ),
                   ),
-                const SizedBox(
-                  width: 10,
-                ),
+                if (loc != null &&
+                    loc.direction != null &&
+                    loc.direction != INV_DIR)
+                  const SizedBox(
+                    width: 10,
+                  ),
                 Text(
                   directionAsString(loc?.direction),
                   style: const TextStyle(

--- a/lib/widgets/sliders/aircraft/detail/operator_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/operator_fields.dart
@@ -182,13 +182,13 @@ class OperatorFields {
           AircraftDetailField(
             headlineText: 'Area Ceiling',
             fieldText: systemDataValid
-                ? '${systemMessage!.areaCeiling.toString()}  m'
+                ? getAltitudeAsString(systemMessage!.areaCeiling)
                 : 'Unknown',
           ),
           AircraftDetailField(
             headlineText: 'Area Floor',
             fieldText: systemDataValid
-                ? '${systemMessage!.areaFloor.toString()} m'
+                ? getAltitudeAsString(systemMessage!.areaFloor)
                 : 'Unknown',
           ),
         ],


### PR DESCRIPTION
In aircraft detail, invalid values for area floor/ceil, vert/hori speed were still not detected.
There was also a bug in lib in parsing these values, solved by commit [1](https://github.com/dronetag/flutter-opendroneid/commit/d2a9a17e96b80aad175817bed682aaf513430477) and [2](https://github.com/dronetag/flutter-opendroneid/commit/9a0d998f12bca1856e86bedcc53c8c0873ba8810)