### PR TITLE
Fix: handling scanning state

### DIFF
--- a/lib/bloc/opendroneid_cubit.dart
+++ b/lib/bloc/opendroneid_cubit.dart
@@ -64,8 +64,12 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
     );
   }
 
-  void initBtListener() => btStateListener =
-      FlutterOpenDroneId.bluetoothState.listen(btStateCallback);
+  void initBtListener() =>
+      btStateListener = FlutterOpenDroneId.bluetoothState.listen(
+        (scanning) => btStateCallback(
+          isScanning: scanning,
+        ),
+      );
 
   void cancelListener() {
     listener?.cancel();
@@ -73,18 +77,17 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
     wifiStateListener?.cancel();
   }
 
-  void btStateCallback(BluetoothState btstate) {
+  void btStateCallback({required bool isScanning}) {
     // refresh ui just when state changes
-    if ((btstate == BluetoothState.PoweredOn) == state.isScanningBluetooth) {
+    if (isScanning == state.isScanningBluetooth) {
       return;
     }
     emit(
-      state.copyWith(isScanningBluetooth: btstate == BluetoothState.PoweredOn),
+      state.copyWith(isScanningBluetooth: isScanning),
     );
   }
 
   void wifiStateCallback({required bool isScanning}) {
-    print('wifi state callback ' + isScanning.toString());
     // refresh ui just when state changes
     if (isScanning == state.isScanningWifi) {
       return;

--- a/lib/bloc/opendroneid_cubit.dart
+++ b/lib/bloc/opendroneid_cubit.dart
@@ -84,6 +84,7 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
   }
 
   void wifiStateCallback({required bool isScanning}) {
+    print('wifi state callback ' + isScanning.toString());
     // refresh ui just when state changes
     if (isScanning == state.isScanningWifi) {
       return;
@@ -116,6 +117,10 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
 
   Future<bool> isBtTurnedOn() async {
     return FlutterOpenDroneId.btTurnedOn;
+  }
+
+  Future<bool> isWifiTurnedOn() async {
+    return FlutterOpenDroneId.wifiTurnedOn;
   }
 
   Future<void> stop() async {

--- a/lib/widgets/toolbars/components/scanning_state_icons.dart
+++ b/lib/widgets/toolbars/components/scanning_state_icons.dart
@@ -30,8 +30,9 @@ class ScanningStateIcons extends StatelessWidget {
                     .isBtTurnedOn()
                     .then((turnedOn) {
                   if (turnedOn) {
-                    if (state.usedTechnologies == UsedTechnologies.Bluetooth ||
-                        state.usedTechnologies == UsedTechnologies.Both) {
+                    if (state.isScanningBluetooth &&
+                        (state.usedTechnologies == UsedTechnologies.Bluetooth ||
+                            state.usedTechnologies == UsedTechnologies.Both)) {
                       context.read<OpendroneIdCubit>().setBtUsed(btUsed: false);
                       snackBarText = 'Bluetooth Scanning Stopped.';
                     } else {

--- a/lib/widgets/toolbars/components/scanning_state_icons.dart
+++ b/lib/widgets/toolbars/components/scanning_state_icons.dart
@@ -44,7 +44,6 @@ class ScanningStateIcons extends StatelessWidget {
                     showSnackBar(
                       context,
                       snackBarText,
-                      textColor: AppColors.red,
                     );
                   }
                 });
@@ -84,19 +83,33 @@ class ScanningStateIcons extends StatelessWidget {
               return RawMaterialButton(
                 onPressed: () {
                   late final String snackBarText;
-                  if (state.usedTechnologies == UsedTechnologies.Wifi ||
-                      state.usedTechnologies == UsedTechnologies.Both) {
-                    context
-                        .read<OpendroneIdCubit>()
-                        .setWifiUsed(wifiUsed: false);
-                    snackBarText = 'Wi-Fi Scanning Stopped.';
-                  } else {
-                    context
-                        .read<OpendroneIdCubit>()
-                        .setWifiUsed(wifiUsed: true);
-                    snackBarText = 'Wi-Fi Scanning Started.';
-                  }
-                  showSnackBar(context, snackBarText);
+                  context
+                      .read<OpendroneIdCubit>()
+                      .isWifiTurnedOn()
+                      .then((turnedOn) {
+                    if (turnedOn) {
+                      if (state.isScanningWifi &&
+                              state.usedTechnologies == UsedTechnologies.Wifi ||
+                          state.usedTechnologies == UsedTechnologies.Both) {
+                        context
+                            .read<OpendroneIdCubit>()
+                            .setWifiUsed(wifiUsed: false);
+                        snackBarText = 'Wi-Fi Scanning Stopped.';
+                      } else {
+                        context
+                            .read<OpendroneIdCubit>()
+                            .setWifiUsed(wifiUsed: true);
+                        snackBarText = 'Wi-Fi Scanning Started.';
+                      }
+                      showSnackBar(context, snackBarText);
+                    } else {
+                      snackBarText = 'Turn Wi-Fi on to start scanning.';
+                      showSnackBar(
+                        context,
+                        snackBarText,
+                      );
+                    }
+                  });
                 },
                 //padding: const EdgeInsets.all(8),
                 constraints: const BoxConstraints(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "31.0.0"
+    version: "47.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.0"
+    version: "4.7.0"
   app_settings:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   charcode:
     dependency: transitive
     description:
@@ -71,13 +71,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.3.5"
   clock:
     dependency: transitive
     description:
@@ -215,7 +208,7 @@ packages:
       name: flutter_opendroneid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.1"
+    version: "0.9.4"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -360,14 +353,14 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mime:
     dependency: transitive
     description:
@@ -542,7 +535,7 @@ packages:
       name: pigeon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.19"
+    version: "3.2.9"
   platform:
     dependency: transitive
     description:
@@ -941,5 +934,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
-  flutter: ">=3.0.5"
+  dart: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_opendroneid: 0.9.1
+  flutter_opendroneid: 0.9.4
   sprintf: "^6.0.0"
   flutter_google_places_hoc081098: 1.1.0
   google_api_headers: ^1.1.1


### PR DESCRIPTION
Solve cases when Bt/Wi-Fi is turned off. Check if Wi-Fi is available before starting scans.
Depending on the phone settings, we can scan even with Wi-Fi turned off.

Uses updated API of flutter-opendroneid, depends on [PR 4](https://github.com/dronetag/flutter-opendroneid/pull/4)