### PR TITLE
fix: add debounce timer to google places autocomplete

### DIFF
--- a/lib/widgets/toolbars/components/location_search.dart
+++ b/lib/widgets/toolbars/components/location_search.dart
@@ -27,6 +27,7 @@ class _LocationSearchState extends State<LocationSearch> {
       context: context,
       apiKey: googleApikey,
       types: [],
+      debounce: Duration(milliseconds: 1500),
       strictbounds: false,
     );
 


### PR DESCRIPTION
Debounce timer prevents calling google api on every keystroke, request is send after 1.5 sec after user stops writing.