### PR TITLE
Use default snackbar elevation

### DIFF
--- a/lib/widgets/app/dialogs.dart
+++ b/lib/widgets/app/dialogs.dart
@@ -46,7 +46,6 @@ void showSnackBar(
   Color textColor = Colors.white,
 }) {
   final snackBar = SnackBar(
-    elevation: MediaQuery.of(context).size.height / 2,
     backgroundColor: AppColors.darkGray.withOpacity(AppColors.toolbarOpacity),
     duration: const Duration(milliseconds: 1500),
     behavior: SnackBarBehavior.floating,


### PR DESCRIPTION
The elevation of snackbar used so far was nonsensically high, it probably caused high memory consumption.