### PR TITLE
Remove query_all_packages permission from Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,8 +14,14 @@
     <uses-permission android:name="android.permission.ACCESS_LOCATION_EXTRA_COMMANDS"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
-   <application
+
+    <queries>
+        <intent> 
+            <action android:name="android.intent.action.VIEW" /> 
+                <data android:scheme="https" /> 
+        </intent>
+    </queries>
+    <application
         android:label="Drone Scanner"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,5 +53,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+  		<string>https</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The permission allows to interact with all installed apps. We need to interact just with the web browser, so I added <queries> element instead with intent to open web pages.

Also adds related LSApplicationQueriesSchemes entry to info.plist, as recommended in url_launcher package readme.
