### PR TITLE
Fix: disable lock on unknown location

### DIFF
--- a/lib/bloc/map/map_cubit.dart
+++ b/lib/bloc/map/map_cubit.dart
@@ -111,6 +111,10 @@ class MapCubit extends Cubit<GMapState> {
     emit(state.copyWith(lockOnPoint: !state.lockOnPoint));
   }
 
+  Future<void> turnOffLockOnPoint() async {
+    emit(state.copyWith(lockOnPoint: false));
+  }
+
   Future<void> setUserLocation(gmap.LatLng loc) async {
     emit(state.copyWith(userLocation: loc, userLocationValid: true));
   }
@@ -198,6 +202,7 @@ class MapCubit extends Cubit<GMapState> {
                 onTap: () {
                   context.read<SelectedZoneCubit>().selectZone(e);
                   context.read<SelectedAircraftCubit>().unselectAircraft();
+                  context.read<MapCubit>().turnOffLockOnPoint();
                   context.read<MapCubit>().centerToLocDouble(
                         e.coordinates.first.latitude,
                         e.coordinates.first.longitude,
@@ -236,6 +241,7 @@ class MapCubit extends Cubit<GMapState> {
                 onTap: () {
                   context.read<SelectedZoneCubit>().selectZone(e);
                   context.read<SelectedAircraftCubit>().unselectAircraft();
+                  context.read<MapCubit>().turnOffLockOnPoint();
                   context.read<MapCubit>().centerToLocDouble(
                         e.coordinates.first.latitude,
                         e.coordinates.first.longitude,

--- a/lib/widgets/mainpage/map_ui_google.dart
+++ b/lib/widgets/mainpage/map_ui_google.dart
@@ -91,6 +91,7 @@ class _MapUIGoogleState extends State<MapUIGoogle> with WidgetsBindingObserver {
       onTap: selItemMac != null || selZone != null || droppedPin
           ? (_) {
               context.read<SelectedAircraftCubit>().unselectAircraft();
+              context.read<MapCubit>().turnOffLockOnPoint();
               context.read<SelectedZoneCubit>().unselectZone();
               FocusScope.of(context).unfocus();
               context.read<MapCubit>().setDroppedPin(pinDropped: false);

--- a/lib/widgets/preferences/preferences_page.dart
+++ b/lib/widgets/preferences/preferences_page.dart
@@ -7,6 +7,7 @@ import '../../bloc/aircraft/aircraft_cubit.dart';
 import '../../bloc/aircraft/aircraft_expiration_cubit.dart';
 import '../../bloc/aircraft/selected_aircraft_cubit.dart';
 import '../../bloc/help/help_cubit.dart';
+import '../../bloc/map/map_cubit.dart';
 import '../../bloc/showcase_cubit.dart';
 import '../../bloc/sliders_cubit.dart';
 import '../../bloc/standards_cubit.dart';
@@ -444,6 +445,7 @@ class PreferencesPage extends StatelessWidget {
                   context.read<SlidersCubit>().setShowDroneDetail(show: false);
                   context.read<AircraftCubit>().clear();
                   context.read<SelectedAircraftCubit>().unselectAircraft();
+                  context.read<MapCubit>().turnOffLockOnPoint();
                 },
               );
             },

--- a/lib/widgets/sliders/aircraft/aircraft_actions.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_actions.dart
@@ -20,6 +20,15 @@ Future<AircraftAction?> displayAircraftActionMenu(BuildContext context) async {
   final labelStyle = TextStyle(
     fontSize: 16,
   );
+  final selectedMac =
+      context.read<SelectedAircraftCubit>().state.selectedAircraftMac;
+  if (selectedMac == null) return null;
+  final messagePackList = context.read<AircraftCubit>().packsForDevice(
+        selectedMac,
+      );
+  if (messagePackList == null || messagePackList.isEmpty) {
+    return null;
+  }
   return showMenu<AircraftAction>(
     context: context,
     shape: RoundedRectangleBorder(
@@ -33,6 +42,8 @@ Future<AircraftAction?> displayAircraftActionMenu(BuildContext context) async {
           horizontal: 20,
         ),
         value: AircraftAction.mapLock,
+        enabled:
+            messagePackList.isNotEmpty && messagePackList.last.locationValid(),
         child: Text(
           context.read<MapCubit>().state.lockOnPoint
               ? 'Unfollow'

--- a/lib/widgets/sliders/aircraft/aircraft_actions.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_actions.dart
@@ -104,6 +104,7 @@ void handleAction(BuildContext context, AircraftAction action) {
           context.read<SlidersCubit>().setShowDroneDetail(show: false);
           context.read<AircraftCubit>().deletePack(selectedMac);
           context.read<SelectedAircraftCubit>().unselectAircraft();
+          context.read<MapCubit>().turnOffLockOnPoint();
           showSnackBar(
             context,
             'Aircraft data were deleted.',

--- a/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
+++ b/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
@@ -4,6 +4,7 @@ import 'package:flutter_opendroneid/models/message_pack.dart';
 
 import '../../../../bloc/aircraft/aircraft_cubit.dart';
 import '../../../../bloc/aircraft/selected_aircraft_cubit.dart';
+import '../../../../bloc/map/map_cubit.dart';
 import '../../../../bloc/screen_cubit.dart';
 import '../../../../bloc/showcase_cubit.dart';
 import '../../../../bloc/sliders_cubit.dart';
@@ -118,10 +119,10 @@ class AircraftDetailHeader extends StatelessWidget {
                 size: Sizes.detailIconSize,
               ),
               onPressed: () {
-                // on tap to map, unfocus other widgets and unselect aircraft
                 context.read<SlidersCubit>().setShowDroneDetail(show: false);
                 context.read<SelectedZoneCubit>().unselectZone();
                 context.read<SelectedAircraftCubit>().unselectAircraft();
+                context.read<MapCubit>().turnOffLockOnPoint();
               },
             ),
           ),

--- a/lib/widgets/sliders/common/airspace_list.dart
+++ b/lib/widgets/sliders/common/airspace_list.dart
@@ -133,6 +133,7 @@ class AirspaceList extends StatelessWidget {
                     context
                         .read<SelectedAircraftCubit>()
                         .selectAircraft(value.last.macAddress);
+                    context.read<MapCubit>().turnOffLockOnPoint();
                     context.read<SelectedZoneCubit>().unselectZone();
                     if (value.last.locationValid()) {
                       context.read<MapCubit>().centerToLocDouble(
@@ -162,6 +163,7 @@ class AirspaceList extends StatelessWidget {
                         context
                             .read<SelectedAircraftCubit>()
                             .unselectAircraft();
+                        context.read<MapCubit>().turnOffLockOnPoint();
                         context.read<MapCubit>().centerToLocDouble(
                               z.coordinates.first.latitude,
                               z.coordinates.first.longitude,

--- a/lib/widgets/toolbars/map_options_toolbar.dart
+++ b/lib/widgets/toolbars/map_options_toolbar.dart
@@ -99,6 +99,7 @@ class MapOptionsToolbar extends StatelessWidget {
                         context
                             .read<SelectedAircraftCubit>()
                             .unselectAircraft();
+                        context.read<MapCubit>().turnOffLockOnPoint();
                         showSnackBar(
                           context,
                           'All the gathered aircraft data were deleted.',


### PR DESCRIPTION
Disable option to follow aircraft if its location is not valid. Turn of lock if other aircraft is selected or selected is deleted.