### PR TITLE
Fix: unknown values in messages from aircraft

### DIFF
--- a/lib/constants/sizes.dart
+++ b/lib/constants/sizes.dart
@@ -6,7 +6,7 @@ class Sizes {
   static const toolbarMinSizeRatioLandscape = 12;
   static const panelBorderRadius = 10.0;
   static const toolbarHeight = 50.0;
-  static const cardIconSize = 32.0;
+  static const cardIconSize = 28.0;
   static const iconSize = 25.0;
   static const detailIconSize = 30.0;
   static const textIconSize = 20.0;

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -93,22 +93,21 @@ class AircraftCard extends StatelessWidget {
 
   Widget buildLeading(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    final isAirborne =
-        messagePack.locationMessage?.status == pigeon.AircraftStatus.Airborne;
-    final icon = Image.asset(
-      isAirborne
-          ? 'assets/images/plane_airborne.png'
-          : 'assets/images/plane_grounded.png',
-      width: Sizes.cardIconSize,
-      height: Sizes.cardIconSize,
-    );
+    final status = messagePack.locationMessage?.status;
+
+    final icon = status == pigeon.AircraftStatus.Undeclared
+        ? null
+        : Image.asset(
+            status == pigeon.AircraftStatus.Airborne
+                ? 'assets/images/plane_airborne.png'
+                : 'assets/images/plane_grounded.png',
+            width: Sizes.cardIconSize,
+            height: Sizes.cardIconSize,
+          );
     final isLandscape =
         MediaQuery.of(context).orientation == Orientation.landscape;
 
-    final aircraftText = messagePack.locationMessage == null ||
-            messagePack.locationMessage!.status == pigeon.AircraftStatus.Ground
-        ? 'Grounded'
-        : '${messagePack.locationMessage!.height.toString()}m AGL';
+    final aircraftText = _getAircraftText();
     return SizedBox(
       width: width / 6,
       child: Align(
@@ -116,7 +115,13 @@ class AircraftCard extends StatelessWidget {
         child: Wrap(
           direction: isLandscape ? Axis.vertical : Axis.horizontal,
           children: [
-            Padding(padding: EdgeInsets.only(left: 6.0), child: icon),
+            Padding(
+                padding: EdgeInsets.only(left: 6.0),
+                child: icon ??
+                    Icon(
+                      Icons.error_outline,
+                      size: Sizes.cardIconSize,
+                    )),
             const SizedBox(
               height: 2,
             ),
@@ -125,7 +130,9 @@ class AircraftCard extends StatelessWidget {
               style: TextStyle(
                 fontWeight: FontWeight.w700,
                 fontSize: 12.0,
-                color: isAirborne ? AppColors.highlightBlue : AppColors.dark,
+                color: status == pigeon.AircraftStatus.Airborne
+                    ? AppColors.highlightBlue
+                    : AppColors.dark,
               ),
             ),
           ],
@@ -197,5 +204,15 @@ class AircraftCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _getAircraftText() {
+    if (messagePack.locationMessage == null) return 'Undeclared Status';
+    final status = messagePack.locationMessage!.status;
+    return status == pigeon.AircraftStatus.Ground
+        ? 'Grounded'
+        : status == pigeon.AircraftStatus.Airborne
+            ? '${messagePack.locationMessage!.height.toString()}m AGL'
+            : 'Undeclared Status';
   }
 }

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -104,32 +104,28 @@ class AircraftCard extends StatelessWidget {
             width: Sizes.cardIconSize,
             height: Sizes.cardIconSize,
           );
-    final isLandscape =
-        MediaQuery.of(context).orientation == Orientation.landscape;
 
     final aircraftText = _getAircraftText();
-    return SizedBox(
+    return Container(
       width: width / 6,
+      margin: EdgeInsets.only(right: 2.0),
       child: Align(
         alignment: Alignment.centerLeft,
-        child: Wrap(
-          direction: isLandscape ? Axis.vertical : Axis.horizontal,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Padding(
-                padding: EdgeInsets.only(left: 6.0),
-                child: icon ??
-                    Icon(
-                      Icons.error_outline,
-                      size: Sizes.cardIconSize,
-                    )),
-            const SizedBox(
-              height: 2,
-            ),
+            icon ??
+                Icon(
+                  Icons.help_outline,
+                  size: Sizes.cardIconSize,
+                ),
             Text(
               aircraftText,
+              textAlign: TextAlign.center,
               style: TextStyle(
                 fontWeight: FontWeight.w700,
-                fontSize: 12.0,
+                fontSize: 11.0,
                 color: status == pigeon.AircraftStatus.Airborne
                     ? AppColors.highlightBlue
                     : AppColors.dark,
@@ -207,12 +203,12 @@ class AircraftCard extends StatelessWidget {
   }
 
   String _getAircraftText() {
-    if (messagePack.locationMessage == null) return 'Unknown Status';
+    if (messagePack.locationMessage == null) return 'Unknown';
     final status = messagePack.locationMessage!.status;
     return status == pigeon.AircraftStatus.Ground
         ? 'Grounded'
         : status == pigeon.AircraftStatus.Airborne
             ? '${messagePack.locationMessage!.height.toString()}m AGL'
-            : 'Unknown Status';
+            : 'Unknown';
   }
 }

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -207,12 +207,12 @@ class AircraftCard extends StatelessWidget {
   }
 
   String _getAircraftText() {
-    if (messagePack.locationMessage == null) return 'Undeclared Status';
+    if (messagePack.locationMessage == null) return 'Unknown Status';
     final status = messagePack.locationMessage!.status;
     return status == pigeon.AircraftStatus.Ground
         ? 'Grounded'
         : status == pigeon.AircraftStatus.Airborne
             ? '${messagePack.locationMessage!.height.toString()}m AGL'
-            : 'Undeclared Status';
+            : 'Unknown Status';
   }
 }

--- a/lib/widgets/sliders/aircraft/aircraft_card_title.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card_title.dart
@@ -27,12 +27,14 @@ class AircraftCardTitle extends StatelessWidget {
           fontSize: 16.0,
         ),
         children: [
-          if (givenLabel == null && manufacturer != null && logo != null)
+          if (givenLabel == null && manufacturer != null && logo != null) ...[
             WidgetSpan(
               alignment: PlaceholderAlignment.middle,
               child: logo,
             ),
-          if (givenLabel != null)
+            TextSpan(text: ' '),
+          ],
+          if (givenLabel != null) ...[
             WidgetSpan(
               alignment: PlaceholderAlignment.middle,
               child: Icon(
@@ -41,8 +43,10 @@ class AircraftCardTitle extends StatelessWidget {
                 color: Colors.black,
               ),
             ),
+            TextSpan(text: ' '),
+          ],
           TextSpan(
-            text: givenLabel == null ? ' $uasId' : ' $givenLabel',
+            text: givenLabel == null ? '$uasId' : '$givenLabel',
           ),
         ],
       ),

--- a/lib/widgets/sliders/aircraft/detail/location_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/location_fields.dart
@@ -64,17 +64,19 @@ class LocationFields {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  Icon(
-                    loc.status == pigeon.AircraftStatus.Airborne
-                        ? Icons.flight_takeoff
-                        : Icons.flight_land,
-                    color: loc.status == pigeon.AircraftStatus.Airborne
-                        ? AppColors.highlightBlue
-                        : AppColors.dark,
-                  ),
-                  const SizedBox(
-                    width: 10,
-                  ),
+                  if (loc.status != pigeon.AircraftStatus.Undeclared) ...[
+                    Icon(
+                      loc.status == pigeon.AircraftStatus.Airborne
+                          ? Icons.flight_takeoff
+                          : Icons.flight_land,
+                      color: loc.status == pigeon.AircraftStatus.Airborne
+                          ? AppColors.highlightBlue
+                          : AppColors.dark,
+                    ),
+                    const SizedBox(
+                      width: 10,
+                    ),
+                  ],
                   Text(
                     loc.status.toString().replaceAll('AircraftStatus.', ''),
                     style: TextStyle(

--- a/lib/widgets/sliders/aircraft/detail/location_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/location_fields.dart
@@ -78,7 +78,7 @@ class LocationFields {
                     ),
                   ],
                   Text(
-                    loc.status.toString().replaceAll('AircraftStatus.', ''),
+                    _getStatusText(loc),
                     style: TextStyle(
                       color: loc.status == pigeon.AircraftStatus.Airborne
                           ? AppColors.highlightBlue
@@ -239,5 +239,15 @@ class LocationFields {
         fieldText: timeAccuracyToString(loc?.timeAccuracy),
       ),
     ];
+  }
+
+  static String _getStatusText(pigeon.LocationMessage? loc) {
+    if (loc == null) return 'Unknown';
+    final status = loc!.status;
+    return status == pigeon.AircraftStatus.Ground
+        ? 'Grounded'
+        : status == pigeon.AircraftStatus.Airborne
+            ? 'Airborne'
+            : 'Unknown';
   }
 }

--- a/lib/widgets/sliders/aircraft/detail/operator_fields.dart
+++ b/lib/widgets/sliders/aircraft/detail/operator_fields.dart
@@ -202,6 +202,7 @@ class OperatorFields {
                 ? systemMessage!.category
                     .toString()
                     .replaceAll('AircraftCategory.', '')
+                    .replaceAll('_', ' ')
                 : 'Unknown',
           ),
           AircraftDetailField(
@@ -210,6 +211,7 @@ class OperatorFields {
                 ? systemMessage!.classValue
                     .toString()
                     .replaceAll('AircraftClass.', '')
+                    .replaceAll('_', ' ')
                 : 'Unknown',
           ),
         ],

--- a/lib/widgets/sliders/common/airspace_list.dart
+++ b/lib/widgets/sliders/common/airspace_list.dart
@@ -72,7 +72,7 @@ class AirspaceList extends StatelessWidget {
                       shrinkWrap: true,
                       itemBuilder: (context, index) {
                         return Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 8.0),
+                          padding: const EdgeInsets.symmetric(vertical: 4.0),
                           child: children[index],
                         );
                       },


### PR DESCRIPTION
Handle cases with unknown values for all possible fields of remote id messages, e.g. do not show grounded/airborne aircraft icons in card/detail when status is unknown.