### PR TITLE
Fix: map trajectories

### DIFF
--- a/lib/bloc/aircraft/aircraft_cubit.dart
+++ b/lib/bloc/aircraft/aircraft_cubit.dart
@@ -24,6 +24,8 @@ class AircraftCubit extends Cubit<AircraftState> {
   // storage for user-given labels
   final LocalStorage storage = LocalStorage('dronescanner');
 
+  static const uiUpdateIntervalMs = 200;
+
   // data for showcase
   final List<MessagePack> _packs = [
     MessagePack(
@@ -83,7 +85,11 @@ class AircraftCubit extends Cubit<AircraftState> {
   }
 
   // timer used to notify UI
-  void initEmitTimer({Duration duration = const Duration(milliseconds: 500)}) {
+  void initEmitTimer({
+    Duration duration = const Duration(
+      milliseconds: uiUpdateIntervalMs,
+    ),
+  }) {
     stopEmitTimer();
     _refreshTimer = Timer.periodic(
       duration,

--- a/lib/bloc/map/map_cubit.dart
+++ b/lib/bloc/map/map_cubit.dart
@@ -25,6 +25,8 @@ class MapCubit extends Cubit<GMapState> {
     target: gmap.LatLng(50.5, 14.25),
     zoom: 11.0,
   );
+  static const maxPolylinePoints = 500;
+
   List<VoidCallback> postLoadCallbacks = [];
 
   MapCubit(LocationService locationService)
@@ -391,16 +393,15 @@ class MapCubit extends Cubit<GMapState> {
     selItemHistory =
         context.read<AircraftCubit>().state.packHistory()[selItemMac];
     if (selItemHistory == null) return {};
-    const maxPoints = 75;
     var filteredList = <MessagePack>[];
     // calc portion of history that will be filtered out
-    final skip = selItemHistory.length ~/ maxPoints;
+    final skip = (selItemHistory.length / maxPolylinePoints);
 
     if (skip <= 1) {
       filteredList = selItemHistory;
     } else {
       for (var i = 0; i < selItemHistory.length; ++i) {
-        if ((i % skip) == 0) {
+        if ((i % skip) < 1) {
           filteredList.add(selItemHistory[i]);
         }
       }

--- a/lib/bloc/map/map_cubit.dart
+++ b/lib/bloc/map/map_cubit.dart
@@ -25,7 +25,7 @@ class MapCubit extends Cubit<GMapState> {
     target: gmap.LatLng(50.5, 14.25),
     zoom: 11.0,
   );
-  static const maxPolylinePoints = 500;
+  static const maxPolylinePoints = 400;
 
   List<VoidCallback> postLoadCallbacks = [];
 

--- a/lib/bloc/opendroneid_cubit.dart
+++ b/lib/bloc/opendroneid_cubit.dart
@@ -53,6 +53,8 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
   SelectedAircraftCubit selectedAircraftCubit;
   AircraftCubit aircraftCubit;
 
+  static const messageDebounceMs = 50;
+
   OpendroneIdCubit({
     required this.mapCubit,
     required this.selectedAircraftCubit,
@@ -141,7 +143,7 @@ class OpendroneIdCubit extends Cubit<ScanningState> {
     try {
       await FlutterOpenDroneId.startScan(usedTechnology);
       listener = FlutterOpenDroneId.allMessages
-          .debounceTime(Duration(milliseconds: 100))
+          .debounceTime(Duration(milliseconds: messageDebounceMs))
           .listen(scanCallback);
       aircraftCubit.initEmitTimer();
     } on PermissionsMissingException catch (e) {


### PR DESCRIPTION
Change algorithm that filters out points from trajectory when max number of points is reached. Change debouncing time and set max points in trajectory to 400. The number was worked out experimentally, so map does not lag when trajectory is shown on oldest possible phones.