### PR TITLE
feat: Add `dronescanner` scheme

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,7 +55,7 @@
 	<true/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-  		<string>https</string>
+  		<string>dronescanner</string>
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>


### PR DESCRIPTION
Set scheme to be able to open the app from another app on iOS.