### PR TITLE
Feature: define url scheme on ios

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -22,8 +22,25 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>dronescanner</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>dronescanner</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>https</string>
+	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>
@@ -36,6 +53,8 @@
 	<string>Application needs Your location to show nearby aircraft.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Application needs Your location to show nearby aircraft.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -52,12 +71,6 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<true/>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-  		<string>https</string>
-	</array>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -55,7 +55,7 @@
 	<true/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
-  		<string>dronescanner</string>
+  		<string>https</string>
 	</array>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>


### PR DESCRIPTION
Set URL name, role and scheme in  `CFBundleURLTypes` element in in _Info.plist_. I set up opening from other apps according to [this post](https://stackoverflow.com/a/59648933).