### PR TITLE
fix: android storage permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
     <uses-permission
         android:name="android.permission.NEARBY_WIFI_DEVICES"
         android:usesPermissionFlags="neverForLocation" />
-    
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
 
     <queries>
         <intent> 

--- a/lib/bloc/aircraft/aircraft_cubit.dart
+++ b/lib/bloc/aircraft/aircraft_cubit.dart
@@ -296,26 +296,37 @@ class AircraftCubit extends Cubit<AircraftState> {
   }
 
   Future<bool> checkStoragePermission() async {
-    // Check for relevant permissions.
-    // Since Android SDK 33, storage is not used
-    final deviceInfo = DeviceInfoPlugin();
-    final androidInfo = await deviceInfo.androidInfo;
-    if (Platform.isIOS || androidInfo.version.sdkInt < 33) {
-      final storage = await Permission.storage.status.isGranted;
-      if (!storage) {
-        return await Permission.storage.request().isGranted;
-      }
-      return storage;
+    if (Platform.isIOS) {
+      return _storagePermissionCheck();
     } else {
-      var videos = await Permission.videos.status.isGranted;
-      var photos = await Permission.photos.status.isGranted;
-      if (!videos || !photos) {
-        // request at once, will produce 1 dialog
-        videos = await Permission.videos.request().isGranted;
-        photos = await Permission.videos.request().isGranted;
+      final deviceInfo = DeviceInfoPlugin();
+      final androidInfo = await deviceInfo.androidInfo;
+      // Since Android SDK 33, storage is not used
+      if (androidInfo.version.sdkInt >= 33) {
+        return await _mediaStoragePermissionCheck();
+      } else {
+        return await _storagePermissionCheck();
       }
-      return videos && photos;
     }
+  }
+
+  Future<bool> _storagePermissionCheck() async {
+    final storage = await Permission.storage.status.isGranted;
+    if (!storage) {
+      return await Permission.storage.request().isGranted;
+    }
+    return storage;
+  }
+
+  Future<bool> _mediaStoragePermissionCheck() async {
+    var videos = await Permission.videos.status.isGranted;
+    var photos = await Permission.photos.status.isGranted;
+    if (!videos || !photos) {
+      // request at once, will produce 1 dialog
+      videos = await Permission.videos.request().isGranted;
+      photos = await Permission.videos.request().isGranted;
+    }
+    return videos && photos;
   }
 
   Future<bool> _shareExportFile(String csv, String name) async {


### PR DESCRIPTION
Because target android SDK changed to 33, we need to use video and photo permission for storing files on a device.

Tested on Android 9 (API 28), Android 13 (API 33) and iOS 16.