### PR TITLE
Feature: background tasks, location permission explanation

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />

--- a/lib/bloc/showcase_state.dart
+++ b/lib/bloc/showcase_state.dart
@@ -1,0 +1,67 @@
+part of 'showcase_cubit.dart';
+
+class ShowcaseState {
+  bool showcaseActive;
+  bool showcaseAlreadyPlayed;
+  // keep aircraft state and apply it after showcase ends
+  // so user wont lose data when starting showcase with data already gathered
+  AircraftState? aircraftState;
+
+  ShowcaseState(
+      {required this.showcaseActive,
+      required this.showcaseAlreadyPlayed,
+      this.aircraftState});
+
+  ShowcaseState copyWith({
+    bool? showcaseActive,
+    bool? showcaseAlreadyPlayed,
+    AircraftState? aircraftState,
+  }) =>
+      ShowcaseState(
+        showcaseActive: showcaseActive ?? this.showcaseActive,
+        showcaseAlreadyPlayed:
+            showcaseAlreadyPlayed ?? this.showcaseAlreadyPlayed,
+        aircraftState: aircraftState ?? this.aircraftState,
+      );
+}
+
+class ShowcaseStateNotInitialized extends ShowcaseState {
+  ShowcaseStateNotInitialized({
+    required super.showcaseActive,
+    required super.showcaseAlreadyPlayed,
+    super.aircraftState,
+  });
+
+  @override
+  ShowcaseStateNotInitialized copyWith({
+    bool? showcaseActive,
+    bool? showcaseAlreadyPlayed,
+    AircraftState? aircraftState,
+  }) =>
+      ShowcaseStateNotInitialized(
+        showcaseActive: showcaseActive ?? this.showcaseActive,
+        showcaseAlreadyPlayed:
+            showcaseAlreadyPlayed ?? this.showcaseAlreadyPlayed,
+        aircraftState: aircraftState ?? this.aircraftState,
+      );
+}
+
+class ShowcaseStateInitialized extends ShowcaseState {
+  ShowcaseStateInitialized({
+    required super.showcaseActive,
+    required super.showcaseAlreadyPlayed,
+    super.aircraftState,
+  });
+  @override
+  ShowcaseStateInitialized copyWith({
+    bool? showcaseActive,
+    bool? showcaseAlreadyPlayed,
+    AircraftState? aircraftState,
+  }) =>
+      ShowcaseStateInitialized(
+        showcaseActive: showcaseActive ?? this.showcaseActive,
+        showcaseAlreadyPlayed:
+            showcaseAlreadyPlayed ?? this.showcaseAlreadyPlayed,
+        aircraftState: aircraftState ?? this.aircraftState,
+      );
+}

--- a/lib/widgets/app/app.dart
+++ b/lib/widgets/app/app.dart
@@ -29,13 +29,13 @@ class App extends StatefulWidget {
 class _AppState extends State<App> {
   @override
   Widget build(BuildContext context) {
-    return LifeCycleManager(
-      child: MaterialApp(
-        theme: AppTheme.lightTheme,
-        themeMode: ThemeMode.light,
-        home: const MyHomePage(),
-        navigatorObservers: [NavigationHistoryObserver()],
+    return MaterialApp(
+      theme: AppTheme.lightTheme,
+      themeMode: ThemeMode.light,
+      home: LifeCycleManager(
+        child: const MyHomePage(),
       ),
+      navigatorObservers: [NavigationHistoryObserver()],
     );
   }
 }

--- a/lib/widgets/app/dialogs.dart
+++ b/lib/widgets/app/dialogs.dart
@@ -43,9 +43,10 @@ void showAlertDialog(
   );
 }
 
-Future<bool> showLocationPermissionDialog(
-  BuildContext context,
-) async {
+Future<bool> showLocationPermissionDialog({
+  required BuildContext context,
+  required bool showWhileUsingPermissionExplanation,
+}) async {
   // set up the buttons
   final Widget cancelButton = TextButton(
     child: const Text('Cancel'),
@@ -74,15 +75,16 @@ Future<bool> showLocationPermissionDialog(
         text: 'Drone Scanner requires a location permission to scan for '
             'Bluetooth devices.\n\n',
         children: [
-          TextSpan(
-              text: 'On Android version 11 and newer, please choose\nthe '),
-          TextSpan(
-            text: '\"While using the app\"\n',
-            style: TextStyle(fontWeight: FontWeight.w700),
-          ),
-          TextSpan(
-            text: 'option to enable scans in the background.\n\n',
-          ),
+          if (showWhileUsingPermissionExplanation) ...[
+            TextSpan(text: 'Please choose\nthe '),
+            TextSpan(
+              text: '\"While using the app\"\n',
+              style: TextStyle(fontWeight: FontWeight.w700),
+            ),
+            TextSpan(
+              text: 'option to enable scans in the background.\n\n',
+            ),
+          ],
           TextSpan(
               text: 'If you already denied the permission request,'
                   ' please go to\nthe '),

--- a/lib/widgets/app/dialogs.dart
+++ b/lib/widgets/app/dialogs.dart
@@ -85,7 +85,7 @@ Future<bool> showLocationPermissionDialog(
           ),
           TextSpan(
               text:
-                  'If you already denied the permission request, please go to the '),
+                  'If you already denied the permission request, please go to the\n '),
           TextSpan(
             text: '\"App settings\"\n',
             style: TextStyle(fontWeight: FontWeight.w700),

--- a/lib/widgets/app/dialogs.dart
+++ b/lib/widgets/app/dialogs.dart
@@ -1,4 +1,5 @@
 import 'package:another_flushbar/flushbar.dart';
+import 'package:app_settings/app_settings.dart';
 import 'package:flutter/material.dart';
 
 import '../../constants/colors.dart';
@@ -40,6 +41,73 @@ void showAlertDialog(
       return alert;
     },
   );
+}
+
+Future<bool> showLocationPermissionDialog(
+  BuildContext context,
+) async {
+  // set up the buttons
+  final Widget cancelButton = TextButton(
+    child: const Text('Cancel'),
+    onPressed: () {
+      Navigator.pop(context, false);
+    },
+  );
+  final Widget appSettingsButton = TextButton(
+    child: const Text('App settings'),
+    onPressed: () {
+      Navigator.pop(context, false);
+      AppSettings.openAppSettings();
+    },
+  );
+  final Widget continueButton = TextButton(
+    child: const Text('Continue'),
+    onPressed: () {
+      Navigator.pop(context, true);
+    },
+  );
+  // set up the AlertDialog
+  final alert = AlertDialog(
+    title: const Text('Location permission required'),
+    content: Text.rich(
+      TextSpan(
+        text: 'Drone Scanner requires a location permission to scan for '
+            'Bluetooth devices.\n\n',
+        children: [
+          TextSpan(
+              text: 'On Android version 11 and newer, please choose the\n'),
+          TextSpan(
+            text: '\"While using the app\"\n',
+            style: TextStyle(fontWeight: FontWeight.w700),
+          ),
+          TextSpan(
+            text: 'option to enable scans in the background.\n\n',
+          ),
+          TextSpan(
+              text:
+                  'If you already denied the permission request, please go to the '),
+          TextSpan(
+            text: '\"App settings\"\n',
+            style: TextStyle(fontWeight: FontWeight.w700),
+          ),
+          TextSpan(text: 'and enable location manually.'),
+        ],
+      ),
+    ),
+    actions: [
+      cancelButton,
+      appSettingsButton,
+      continueButton,
+    ],
+  );
+  // show the dialog
+  final result = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      return alert;
+    },
+  );
+  return result ?? false;
 }
 
 void showSnackBar(

--- a/lib/widgets/app/dialogs.dart
+++ b/lib/widgets/app/dialogs.dart
@@ -75,7 +75,7 @@ Future<bool> showLocationPermissionDialog(
             'Bluetooth devices.\n\n',
         children: [
           TextSpan(
-              text: 'On Android version 11 and newer, please choose the\n'),
+              text: 'On Android version 11 and newer, please choose\nthe '),
           TextSpan(
             text: '\"While using the app\"\n',
             style: TextStyle(fontWeight: FontWeight.w700),
@@ -84,8 +84,8 @@ Future<bool> showLocationPermissionDialog(
             text: 'option to enable scans in the background.\n\n',
           ),
           TextSpan(
-              text:
-                  'If you already denied the permission request, please go to the\n '),
+              text: 'If you already denied the permission request,'
+                  ' please go to\nthe '),
           TextSpan(
             text: '\"App settings\"\n',
             style: TextStyle(fontWeight: FontWeight.w700),

--- a/lib/widgets/app/life_cycle_manager.dart
+++ b/lib/widgets/app/life_cycle_manager.dart
@@ -132,11 +132,16 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
   }
 
   Future<void> _initPermissionsAndroid(BuildContext context) async {
+    final version = await getAndroidVersionNumber();
+    if (version == null) return;
     final locStatus = await Permission.location.status;
     // show dialog before asking for location
     // when already granted or pernamently denied, request is not needed
     if (!(locStatus.isGranted || locStatus.isPermanentlyDenied)) {
-      if (await showLocationPermissionDialog(context)) {
+      if (await showLocationPermissionDialog(
+        context: context,
+        showWhileUsingPermissionExplanation: version >= 11,
+      )) {
         final status = await Permission.location.request();
         if (status.isDenied) {
           if (!mounted) return;
@@ -174,8 +179,7 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
     if (!mounted) {
       return;
     }
-    final version = await getAndroidVersionNumber();
-    if (version == null) return;
+
     if ((version >= 13 &&
             await Permission.nearbyWifiDevices.request().isGranted) ||
         version < 13) {

--- a/lib/widgets/app/life_cycle_manager.dart
+++ b/lib/widgets/app/life_cycle_manager.dart
@@ -44,14 +44,14 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
 
   @override
   void didChangeDependencies() {
+    // schedule init after showcase finishes
     SchedulerBinding.instance.addPostFrameCallback(
       (_) {
         final showcaseState = context.read<ShowcaseCubit>().state;
+        // if showcase was not init or is running, listen for finish
         if (showcaseState is ShowcaseStateNotInitialized ||
             showcaseState.showcaseActive) {
           showcaseSub = context.read<ShowcaseCubit>().stream.listen((event) {
-            print(
-                'taggs showcase sub $event active: ${event.showcaseActive} already played: ${event.showcaseAlreadyPlayed}');
             if (event is ShowcaseStateInitialized && !event.showcaseActive) {
               initPlatformState(context);
               showcaseSub?.cancel();

--- a/lib/widgets/mainpage/home_body.dart
+++ b/lib/widgets/mainpage/home_body.dart
@@ -123,8 +123,7 @@ class _HomeBodyState extends State<HomeBody> with WidgetsBindingObserver {
     currentContext = context;
     // rebuild home page when showcase active changes
     context.read<ScreenCubit>().initScreen(context);
-    context.watch<ShowcaseCubit>().state.showcaseActive;
-    context.read<ShowcaseCubit>().displayShowcase().then((status) {
+    context.read<ShowcaseCubit>().shouldDisplayShowcase().then((status) {
       if (status) {
         context.read<ShowcaseCubit>().startShowcase(context);
       }


### PR DESCRIPTION
Add a dialog explaining why we need location permission for BT scanning.

We found out that we need users to select "while using the app" option when they are asked for location permission so background scan would work. Moreover, location will be required by the library after ([PR18](https://github.com/dronetag/flutter-opendroneid/pull/18)). More explanation is in [Jira issue](https://dronetag.atlassian.net/browse/DT-2407) comments.
 
The new dialog is shown before every location request. When user denies location once, system request is then not shown. Unfortunately, we cannot say if user already denied the permission, so dialog is shown every time and If user already dismissed the permission, he can go to app settings using the button.

On the first app start, show all the permission dialogs after the showcase ends.

This will work with current flutter-opendroneid master but the master does not require loc for bt scan so without location it will behave like it scans but no data are outputed. Bump library after ([PR18](https://github.com/dronetag/flutter-opendroneid/pull/18)) is merged.