### PR TITLE
feat: remove use of Zone 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,22 +36,17 @@ const bool kDebugMode = !kReleaseMode && !kProfileMode;
 
 /// Runs app with Sentry monitoring (only for production environment)
 void runAppWithSentry(void Function() appRunner) async {
-  await runZonedGuarded(() async {
-    if (sentryDsn == '') {
-      print('There is no Sentry DSN specified!');
-      appRunner();
-    }
-    await SentryFlutter.init(
-      (options) {
-        options.dsn = sentryDsn;
-        options.debug = kDebugMode;
-      },
-      appRunner: appRunner,
-    );
-  }, (exception, trace) async {
-    print('Unhandled error occurred: $exception $trace');
-    await Sentry.captureException(exception, stackTrace: trace);
-  });
+  if (sentryDsn == '') {
+    print('There is no Sentry DSN specified!');
+    appRunner();
+  }
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = sentryDsn;
+      options.debug = kDebugMode;
+    },
+    appRunner: appRunner,
+  );
 }
 
 void main() async {


### PR DESCRIPTION
Remove `runZonedGuarded`, Sentry captures errors automatically.