### PR TITLE
feat: open correct question in help when navigating from DroneRadar

### DIFF
--- a/lib/bloc/help/help_cubit.dart
+++ b/lib/bloc/help/help_cubit.dart
@@ -12,6 +12,7 @@ class HelpCubit extends Cubit<HelpState> {
       'fields=*,displayed_questions.question.translations.*'
       ',displayed_questions.question.id';
   static const iphoneWifiQuestionIndex = 9;
+  static const droneRadarQuestionIndex = 39;
 
   HelpCubit()
       : super(

--- a/lib/widgets/preferences/proximity_alerts_page.dart
+++ b/lib/widgets/preferences/proximity_alerts_page.dart
@@ -263,8 +263,7 @@ class ProximityAlertsPage extends StatelessWidget {
               context,
               MaterialPageRoute(
                 builder: (context) => const HelpPage(
-                  // TODO: connect to actual question
-                  highlightedQuestionIndex: HelpCubit.iphoneWifiQuestionIndex,
+                  highlightedQuestionIndex: HelpCubit.droneRadarQuestionIndex,
                 ),
                 settings: RouteSettings(
                   name: HelpPage.routeName,


### PR DESCRIPTION
Help question about the Drone Radar feature was finally added to help, point a link from Drone Radar page to it.