### PR TITLE
Debug symbols (DT-2720)

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -5,12 +5,13 @@ name: Delivery
 # later published, for both iOS and Android platforms
 
 env:
-  FLUTTER_VERSION: '3.10.x'
+  FLUTTER_VERSION: "3.10.x"
   DEPLOYMENT_ENV_NAME: production
   IOS_BUNDLE_NAME: cz.dronetag.drone-scanner
   ANDROID_BUNDLE_NAME: cz.dronetag.dronescanner
   ANDROID_TARGET_TRACK: internal
-  FLUTTER_BUILD_NUMBER: '10${{ github.run_number }}'
+  FLUTTER_BUILD_NUMBER: "10${{ github.run_number }}"
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 on:
   push:
@@ -39,17 +40,17 @@ jobs:
     outputs:
       deployment-id: ${{ steps.start.outputs.deployment_id }}
     steps:
-    - name: Start a new deployment
-      uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73
-      id: start
-      with:
-        step: start
-        token: ${{ secrets.GITHUB_TOKEN }}
-        env: ${{ env.DEPLOYMENT_ENV_NAME }}
+      - name: Start a new deployment
+        uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73
+        id: start
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.DEPLOYMENT_ENV_NAME }}
 
   build-publish-ios:
     name: Build & publish iOS bundle
-    needs: 
+    needs:
       - release-version
       - start-deployment
     runs-on: macos-12
@@ -82,6 +83,8 @@ jobs:
           --build-name=$FLUTTER_BUILD_NAME
           --build-number=$FLUTTER_BUILD_NUMBER
           --export-options-plist="$HOME/export_options.plist"
+      - name: Upload debug symbols
+        run: dart run sentry_dart_plugin
       - name: Upload built bundle as artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -98,7 +101,7 @@ jobs:
 
   build-publish-android:
     name: Build & publish Android bundle
-    needs: 
+    needs:
       - release-version
       - start-deployment
     runs-on: ubuntu-22.04
@@ -130,6 +133,8 @@ jobs:
           --release
           --build-name=$FLUTTER_BUILD_NAME
           --build-number=$FLUTTER_BUILD_NUMBER
+      - name: Upload debug symbols
+        run: dart run sentry_dart_plugin
       - name: Upload built bundle as artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -142,7 +147,7 @@ jobs:
         uses: r0adkll/upload-google-play@7406d2c7a1db943b737d959bdefdd7f6d9731f99
         if: ${{ !contains(github.event.head_commit.message, '[skip publish]') && !contains(github.event.head_commit.message, '[skip android publish]') }}
         with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_API_KEY_JSON }} 
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_API_KEY_JSON }}
           packageName: ${{ env.ANDROID_BUNDLE_NAME }}
           releaseFiles: build/app/outputs/bundle/*/*.aab
           track: ${{ env.ANDROID_TARGET_TRACK }}
@@ -159,16 +164,16 @@ jobs:
       - build-publish-ios
       - build-publish-android
     steps:
-    - name: Finish the deployment
-      uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73
-      id: deployment
-      with:
-        step: finish
-        deployment_id: ${{ needs.start-deployment.outputs.deployment-id }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        env: ${{ env.DEPLOYMENT_ENV_NAME }}
-        status: ${{ job.status }}
-        env_url: ${{ inputs.url }}
+      - name: Finish the deployment
+        uses: bobheadxi/deployments@9d4477fdaa4120020cd10ab7e97f68c801422e73
+        id: deployment
+        with:
+          step: finish
+          deployment_id: ${{ needs.start-deployment.outputs.deployment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ env.DEPLOYMENT_ENV_NAME }}
+          status: ${{ job.status }}
+          env_url: ${{ inputs.url }}
 
   announce:
     name: Announce to Slack

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.30"
+  ansicolor:
+    dependency: transitive
+    description:
+      name: ansicolor
+      sha256: "607f8fa9786f392043f169898923e6c59b4518242b68b8862eb8a8b7d9c30b4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   app_settings:
     dependency: "direct main"
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.2"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   cross_file:
     dependency: transitive
     description:
@@ -299,6 +315,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  globbing:
+    dependency: transitive
+    description:
+      name: globbing
+      sha256: "4f89cfaf6fa74c9c1740a96259da06bd45411ede56744e28017cc534a12b6e2d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   google_api_headers:
     dependency: "direct main"
     description:
@@ -387,6 +411,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  injector:
+    dependency: transitive
+    description:
+      name: injector
+      sha256: ed389bed5b48a699d5b9561c985023d0d5cc88dd5ff2237aadcce5a5ab433e4e
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   intl:
     dependency: transitive
     description:
@@ -675,6 +707,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
   provider:
     dependency: transitive
     description:
@@ -739,6 +779,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.9.0"
+  sentry_dart_plugin:
+    dependency: "direct dev"
+    description:
+      name: sentry_dart_plugin
+      sha256: "80f3c22b2e930823c1835a3a4c87468e908ebc555807d367d7e818267548cae3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.2"
   sentry_flutter:
     dependency: "direct main"
     description:
@@ -880,6 +928,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  system_info2:
+    dependency: transitive
+    description:
+      name: system_info2
+      sha256: "65206bbef475217008b5827374767550a5420ce70a04d2d7e94d1d2253f3efc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,10 +13,9 @@ environment:
   flutter: ">=3.10.0"
 
 # # Uncomment to use flutter_opendroneid from local repository
-# dependency_overrides: 
+# dependency_overrides:
 #   flutter_opendroneid:
 #     path: ../flutter-opendroneid
-
 
 dependencies:
   flutter:
@@ -35,7 +34,7 @@ dependencies:
   showcaseview: ^1.1.7
   shared_preferences: ^2.0.13
   device_info_plus: ^8.0.0
-  f_logs: ^2.0.0 
+  f_logs: ^2.0.0
   timer_builder: ^2.0.0
   csv: ^5.0.1
   app_settings: ^4.1.3
@@ -43,7 +42,7 @@ dependencies:
   flutter_bloc: ^8.0.1
   package_info: ^2.0.2
   localstorage: ^4.0.0+1
-  sentry_flutter: ^7.9.0 
+  sentry_flutter: ^7.9.0
   rxdart: ^0.27.5
   vector_math: ^2.1.2
   wakelock: ^0.6.2
@@ -56,6 +55,7 @@ dependencies:
 dev_dependencies:
   dependency_validator: ^3.0.0
   pedantic: ^1.11.0
+  sentry_dart_plugin: ^1.6.2
 
 # The following section is specific to Flutter.
 flutter:
@@ -85,9 +85,19 @@ flutter:
         - asset: assets/fonts/RobotoMono-Regular.ttf
         - asset: assets/fonts/RobotoMono-Bold.ttf
           weight: 700
-    - family:  DroneScannerIcon
+    - family: DroneScannerIcon
       fonts:
         - asset: assets/fonts/DroneScannerIcon.ttf
           weight: 700
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+sentry:
+  upload_debug_symbols: true
+  upload_source_maps: true
+  project: drone-scanner
+  org: dronetag
+  url: https://sentry.dronetag.cz
+  wait_for_processing: false
+  commits: auto
+  ignore_missing: true


### PR DESCRIPTION
This should add the debug symbols to the project release on sentry. I was not able to test it, since the master branch here is protected and the workflow for the toolbox project is not working for quite some time now so I was not able to test it there either. I successfully tried with my own sentry auth token that the setting in the `pubspec.yaml` file is working and the files are being uploaded. This was done according to the commit in the app project and according to the documentation from sentry.

`dart run sentry_dart_plugin` was added to the workflow together with specified  `SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}` environment variable, which should be taken from the organisational setup.