### PR TITLE
Add GPX export format support

### DIFF
--- a/lib/bloc/aircraft/export_cubit.dart
+++ b/lib/bloc/aircraft/export_cubit.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_opendroneid/models/message_container.dart';
+import 'package:flutter_opendroneid/utils/conversions.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../utils/csvlogger.dart';
+import '../../utils/gpxlogger.dart';
+import 'aircraft_cubit.dart';
+
+enum ExportFormat {
+  csv,
+  gpx,
+}
+
+class ExportState {}
+
+class ExportCubit extends Cubit<ExportState> {
+  final AircraftCubit aircraftCubit;
+
+  ExportCubit({required this.aircraftCubit}) : super(ExportState());
+
+  Future<bool> exportAllPacksToCSV() async {
+    final hasPerm = await checkStoragePermission();
+    if (!hasPerm) {
+      return false;
+    }
+    var data = '';
+    aircraftCubit.state.packHistory().forEach((key, value) {
+      data += _createCSV(includeHeader: data == '', packs: value);
+      data += '\n';
+    });
+    if (data.isEmpty) return false;
+    return await _shareExportFile(
+        format: ExportFormat.csv, data: data, name: 'all');
+  }
+
+  Future<bool> exportPack({
+    required ExportFormat format,
+    required String mac,
+  }) async {
+    final aircraftState = aircraftCubit.state;
+    if (aircraftState.packHistory()[mac] == null) return false;
+    // request permission
+    final hasPermission = await checkStoragePermission();
+    if (!hasPermission) return false;
+
+    String? data;
+    if (format == ExportFormat.csv) {
+      data = _createCSV(
+          includeHeader: true, packs: aircraftState.packHistory()[mac]!);
+    } else if (format == ExportFormat.gpx) {
+      data = GPXLogger.createGPX(aircraftState.packHistory()[mac]!);
+    }
+    if (data == null || data.isEmpty) return false;
+
+    return await _shareExportFile(
+        format: format, data: data, name: _createFilename(mac));
+  }
+
+  Future<bool> checkStoragePermission() async {
+    if (Platform.isIOS) {
+      return _storagePermissionCheck();
+    } else {
+      final deviceInfo = DeviceInfoPlugin();
+      final androidInfo = await deviceInfo.androidInfo;
+      // Since Android SDK 33, storage is not used
+      if (androidInfo.version.sdkInt >= 33) {
+        return await _mediaStoragePermissionCheck();
+      } else {
+        return await _storagePermissionCheck();
+      }
+    }
+  }
+
+  String _createCSV(
+          {required bool includeHeader,
+          required List<MessageContainer> packs}) =>
+      const ListToCsvConverter()
+          .convert(CSVLogger.createCSV(packs, includeHeader: includeHeader));
+
+  String _createFilename(String mac) {
+    final aircraftState = aircraftCubit.state;
+
+    late final String filename;
+    if (aircraftState.packHistory()[mac]!.isNotEmpty &&
+        aircraftState
+                .packHistory()[mac]
+                ?.last
+                .basicIdMessage
+                ?.uasID
+                .asString() !=
+            null) {
+      filename = aircraftState
+          .packHistory()[mac]!
+          .last
+          .basicIdMessage!
+          .uasID
+          .asString()!;
+    } else {
+      filename = mac;
+    }
+    return filename;
+  }
+
+  Future<bool> _storagePermissionCheck() async {
+    final storage = await Permission.storage.status.isGranted;
+    if (!storage) {
+      return await Permission.storage.request().isGranted;
+    }
+    return storage;
+  }
+
+  Future<bool> _mediaStoragePermissionCheck() async {
+    var videos = await Permission.videos.status.isGranted;
+    var photos = await Permission.photos.status.isGranted;
+    if (!videos || !photos) {
+      // request at once, will produce 1 dialog
+      videos = await Permission.videos.request().isGranted;
+      photos = await Permission.videos.request().isGranted;
+    }
+    return videos && photos;
+  }
+
+  Future<bool> _shareExportFile(
+      {required ExportFormat format,
+      required String data,
+      required String name}) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final suffix = format == ExportFormat.csv ? 'csv' : 'gpx';
+
+    final pathOfTheFileToWrite =
+        '${directory.path}/drone_scanner_export_$name.$suffix';
+    var file = File(pathOfTheFileToWrite);
+    file = await file.writeAsString(data);
+
+    late final result;
+    if (Platform.isAndroid) {
+      result = await Share.shareXFiles([XFile(pathOfTheFileToWrite)],
+          subject: 'Drone Scanner Export', text: 'Your Remote ID Data');
+    } else {
+      result = await Share.shareXFiles([XFile(pathOfTheFileToWrite)]);
+    }
+    if (result.status == ShareResultStatus.success) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'bloc/aircraft/aircraft_cubit.dart';
 import 'bloc/aircraft/aircraft_expiration_cubit.dart';
+import 'bloc/aircraft/export_cubit.dart';
 import 'bloc/aircraft/selected_aircraft_cubit.dart';
 import 'bloc/help/help_cubit.dart';
 import 'bloc/map/map_cubit.dart';
@@ -108,6 +109,10 @@ void main() async {
           ),
           BlocProvider<AircraftCubit>(
             create: (context) => aircraftCubit,
+            lazy: false,
+          ),
+          BlocProvider<ExportCubit>(
+            create: (context) => ExportCubit(aircraftCubit: aircraftCubit),
             lazy: false,
           ),
           BlocProvider<AircraftExpirationCubit>(

--- a/lib/utils/gpxlogger.dart
+++ b/lib/utils/gpxlogger.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_opendroneid/models/message_container.dart';
+
+class GPXLogger {
+  static String createGPX(
+    List<MessageContainer> list,
+  ) {
+    final gpxBuffer = StringBuffer();
+
+    // GPX header
+    gpxBuffer
+        .writeln('<?xml version="1.0" encoding="UTF-8" standalone="no" ?>');
+    gpxBuffer.writeln(
+        '<gpx version="1.1" xmlns="http://www.topografix.com/GPX/1/1">');
+
+    // Iterate through coordinates and create track points
+    gpxBuffer.writeln('<trk>');
+    gpxBuffer.writeln('<trkseg>');
+    for (final pack in list) {
+      if (!pack.locationValid) continue;
+      gpxBuffer.writeln(
+          '<trkpt lat="${pack.locationMessage!.location!.latitude}" lon="${pack.locationMessage!.location!.longitude}"/>');
+    }
+    gpxBuffer.writeln('</trkseg>');
+    gpxBuffer.writeln('</trk>');
+
+    // GPX footer
+    gpxBuffer.writeln('</gpx>');
+
+    return gpxBuffer.toString();
+  }
+}

--- a/lib/widgets/preferences/preferences_page.dart
+++ b/lib/widgets/preferences/preferences_page.dart
@@ -6,6 +6,7 @@ import 'package:showcaseview/showcaseview.dart';
 
 import '../../bloc/aircraft/aircraft_cubit.dart';
 import '../../bloc/aircraft/aircraft_expiration_cubit.dart';
+import '../../bloc/aircraft/export_cubit.dart';
 import '../../bloc/aircraft/selected_aircraft_cubit.dart';
 import '../../bloc/help/help_cubit.dart';
 import '../../bloc/map/map_cubit.dart';
@@ -531,7 +532,7 @@ class PreferencesPage extends StatelessWidget {
           child: ElevatedButton(
             style: buttonStyle,
             onPressed: () {
-              context.read<AircraftCubit>().exportPacksToCSV().then(
+              context.read<ExportCubit>().exportAllPacksToCSV().then(
                 (value) {
                   if (value) {
                     showSnackBar(context, 'CSV shared successfuly.');

--- a/lib/widgets/sliders/aircraft/aircraft_actions.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_actions.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_opendroneid/utils/conversions.dart';
 
 import '../../../bloc/aircraft/aircraft_cubit.dart';
+import '../../../bloc/aircraft/export_cubit.dart';
 import '../../../bloc/aircraft/selected_aircraft_cubit.dart';
 import '../../../bloc/map/map_cubit.dart';
 import '../../../bloc/proximity_alerts_cubit.dart';
@@ -13,7 +14,8 @@ import '../../app/dialogs.dart';
 
 enum AircraftAction {
   delete,
-  share,
+  shareCsv,
+  shareGpx,
   mapLock,
 }
 
@@ -56,9 +58,19 @@ Future<AircraftAction?> displayAircraftActionMenu(BuildContext context) async {
         padding: EdgeInsets.symmetric(
           horizontal: 20,
         ),
-        value: AircraftAction.share,
+        value: AircraftAction.shareCsv,
         child: Text(
-          'Export Data',
+          'Export to CSV',
+          style: labelStyle,
+        ),
+      ),
+      PopupMenuItem(
+        padding: EdgeInsets.symmetric(
+          horizontal: 20,
+        ),
+        value: AircraftAction.shareGpx,
+        child: Text(
+          'Export to GPX',
           style: labelStyle,
         ),
       ),
@@ -116,14 +128,33 @@ void handleAction(BuildContext context, AircraftAction action) {
         },
       );
       break;
-    case AircraftAction.share:
+    case AircraftAction.shareCsv:
       context
-          .read<AircraftCubit>()
-          .exportPackToCSV(mac: messagePackList.last.macAddress)
+          .read<ExportCubit>()
+          .exportPack(
+              format: ExportFormat.csv, mac: messagePackList.last.macAddress)
           .then(
         (value) {
           if (value) {
             showSnackBar(context, 'CSV shared successfuly.');
+          } else {
+            showSnackBar(
+              context,
+              'Sharing data was not succesful.',
+            );
+          }
+        },
+      );
+      break;
+    case AircraftAction.shareGpx:
+      context
+          .read<ExportCubit>()
+          .exportPack(
+              format: ExportFormat.gpx, mac: messagePackList.last.macAddress)
+          .then(
+        (value) {
+          if (value) {
+            showSnackBar(context, 'GPX shared successfuly.');
           } else {
             showSnackBar(
               context,


### PR DESCRIPTION
Move export functionality from `AircraftCubit` to newly created `ExportCubit`.
Add option to export GPX, which is XML with coordinates and can be imported to various map services.

GPX exported from the app to _mapy.cz_:
<img width="349" alt="Flight exported to mapy.cz" src="https://github.com/dronetag/drone-scanner/assets/15686037/217145a1-3582-4bc2-b22e-7d090a2d6b9d">

Solves the issue https://github.com/dronetag/drone-scanner/issues/64.
DT-2868