### PR TITLE
Chore: update flutter to 3.16

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -5,7 +5,7 @@ name: Delivery
 # later published, for both iOS and Android platforms
 
 env:
-  FLUTTER_VERSION: "3.10.x"
+  FLUTTER_VERSION: "3.16.x"
   DEPLOYMENT_ENV_NAME: production
   IOS_BUNDLE_NAME: cz.dronetag.drone-scanner
   ANDROID_BUNDLE_NAME: cz.dronetag.dronescanner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ name: Integration
 # and runs the unit test suite
 
 env:
-  FLUTTER_VERSION: '3.10.x'
+  FLUTTER_VERSION: '3.16.x'
 
 on:
   pull_request:

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+# platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -105,7 +105,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   flutter_opendroneid: 92e28add32d6bf2b5705fdad0666657476de2e15
   google_maps_flutter_ios: abdac20d6ce8931f6ebc5f46616df241bfaa2cfd
@@ -123,6 +123,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: bf5ce03e0e2088bad9cc378ea97fa0ed5b49673b
   wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
 
-PODFILE CHECKSUM: 5393230c672d3a74e2eae365640a3f251271ea30
+PODFILE CHECKSUM: 720df1fc368a389ed7da69cffcbc4f628f143930
 
 COCOAPODS: 1.14.2

--- a/lib/constants/theme.dart
+++ b/lib/constants/theme.dart
@@ -27,6 +27,7 @@ class AppTheme {
 
   // Light UI Theme
   static final lightTheme = ThemeData(
+    useMaterial3: false,
     // Color scheme
     colorScheme: lightColorScheme,
     brightness: Brightness.light,

--- a/lib/widgets/app/custom_about_dialog.dart
+++ b/lib/widgets/app/custom_about_dialog.dart
@@ -76,7 +76,7 @@ class CustomAboutDialog extends StatelessWidget {
                     ),
                     const Text(
                       'Drone Scanner',
-                      textScaleFactor: 1.6,
+                      textScaler: TextScaler.linear(1.6),
                       style: TextStyle(
                         fontWeight: FontWeight.w600,
                         color: Colors.white,

--- a/lib/widgets/help/help_page.dart
+++ b/lib/widgets/help/help_page.dart
@@ -164,7 +164,7 @@ class HelpPage extends StatelessWidget {
           padding: EdgeInsets.only(bottom: 15.0),
           child: Text(
             'Help',
-            textScaleFactor: 2,
+            textScaler: TextScaler.linear(2),
             style: TextStyle(fontWeight: FontWeight.w600),
           ),
         ),

--- a/lib/widgets/preferences/components/custom_dropdown_button.dart
+++ b/lib/widgets/preferences/components/custom_dropdown_button.dart
@@ -38,7 +38,7 @@ class CustomDropdownButton extends StatelessWidget {
                 value: value,
                 child: Text(
                   value,
-                  textScaleFactor: 0.9,
+                  textScaler: TextScaler.linear(0.9),
                   style: const TextStyle(
                     fontWeight: FontWeight.w700,
                   ),

--- a/lib/widgets/preferences/components/preferences_field_with_description.dart
+++ b/lib/widgets/preferences/components/preferences_field_with_description.dart
@@ -34,7 +34,7 @@ class PreferencesFieldWithDescription extends StatelessWidget {
               ),
               Text(
                 description,
-                textScaleFactor: 0.8,
+                textScaler: TextScaler.linear(0.8),
                 style: const TextStyle(
                   color: AppColors.lightGray,
                 ),

--- a/lib/widgets/preferences/components/proximity_alert_distance_field.dart
+++ b/lib/widgets/preferences/components/proximity_alert_distance_field.dart
@@ -44,7 +44,7 @@ class ProximityAlertDistanceField extends StatelessWidget {
                   Text('Proximity alerts distance'),
                   Text(
                     'Set horizontal distance threshold for proximity alerts',
-                    textScaleFactor: 0.8,
+                    textScaler: TextScaler.linear(0.8),
                     style: const TextStyle(
                       color: AppColors.lightGray,
                     ),

--- a/lib/widgets/preferences/preferences_page.dart
+++ b/lib/widgets/preferences/preferences_page.dart
@@ -162,7 +162,7 @@ class PreferencesPage extends StatelessWidget {
           padding: EdgeInsets.only(bottom: 15.0),
           child: Text(
             'Preferences',
-            textScaleFactor: 2,
+            textScaler: TextScaler.linear(2),
             style: TextStyle(fontWeight: FontWeight.w600),
           ),
         ),
@@ -254,7 +254,7 @@ class PreferencesPage extends StatelessWidget {
           child: Padding(
             padding: itemPadding,
             child: RichText(
-              textScaleFactor: 0.75,
+              textScaler: TextScaler.linear(0.75),
               text: TextSpan(
                 style: const TextStyle(color: AppColors.lightGray),
                 children: <TextSpan>[

--- a/lib/widgets/preferences/proximity_alerts_page.dart
+++ b/lib/widgets/preferences/proximity_alerts_page.dart
@@ -129,7 +129,7 @@ class ProximityAlertsPage extends StatelessWidget {
           padding: EdgeInsets.only(bottom: 15.0),
           child: Text(
             'Drone Radar',
-            textScaleFactor: 2,
+            textScaler: TextScaler.linear(2),
             style: TextStyle(fontWeight: FontWeight.w600),
           ),
         ),

--- a/lib/widgets/showcase/showcase_start_widget.dart
+++ b/lib/widgets/showcase/showcase_start_widget.dart
@@ -34,7 +34,7 @@ class ShowcaseStartWidget extends StatelessWidget {
               children: [
                 Text(
                   heading,
-                  textScaleFactor: 1.5,
+                  textScaler: TextScaler.linear(1.5),
                   textAlign: TextAlign.center,
                   style: const TextStyle(
                     color: AppColors.purple,

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -208,7 +208,7 @@ class AircraftCard extends StatelessWidget {
           ),
           Text(
             "${rssi ?? "?"} dBm",
-            textScaleFactor: 0.7,
+            textScaler: TextScaler.linear(0.7),
             style: TextStyle(
               fontWeight: FontWeight.w600,
               color: AppColors.slate,

--- a/lib/widgets/sliders/aircraft/aircraft_card_custom_text.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card_custom_text.dart
@@ -22,7 +22,7 @@ class AircraftCardCustomText extends StatelessWidget {
 
     const emptyText = Text(
       'Unknown Location',
-      textScaleFactor: 0.9,
+      textScaler: TextScaler.linear(0.9),
     );
     var text = 'Unknown Location';
     if (preference == ListFieldPreference.distance) {
@@ -62,7 +62,7 @@ class AircraftCardCustomText extends StatelessWidget {
 
     return Text(
       text,
-      textScaleFactor: 0.9,
+      textScaler: TextScaler.linear(0.9),
     );
   }
 }

--- a/lib/widgets/sliders/common/num_drones_text.dart
+++ b/lib/widgets/sliders/common/num_drones_text.dart
@@ -40,7 +40,7 @@ class NumDronesText extends StatelessWidget {
         ),
         Text(
           numPacksText,
-          textScaleFactor: 0.9,
+          textScaler: TextScaler.linear(0.9),
         ),
       ],
     );

--- a/lib/widgets/sliders/common/refreshing_text.dart
+++ b/lib/widgets/sliders/common/refreshing_text.dart
@@ -73,7 +73,7 @@ class _RefreshingTextState extends State<RefreshingText> {
         }
         return Text(
           text,
-          textScaleFactor: widget.scaleFactor,
+          textScaler: TextScaler.linear(widget.scaleFactor),
           style: TextStyle(
             color: expiresSoon && widget.showExpiryWarning
                 ? AppColors.red

--- a/lib/widgets/sliders/zones/zone_detail.dart
+++ b/lib/widgets/sliders/zones/zone_detail.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import '/utils/utils.dart';
 import '../../../bloc/map/map_cubit.dart';
 import '../../../bloc/standards_cubit.dart';
 import '../../../bloc/zones/selected_zone_cubit.dart';
 import '../../../bloc/zones/zone_item.dart';
+import '/utils/utils.dart';
 
 class ZoneDetail extends StatelessWidget {
   const ZoneDetail({

--- a/lib/widgets/toolbars/toolbar.dart
+++ b/lib/widgets/toolbars/toolbar.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import './components/toolbar_actions.dart';
 import '../../bloc/showcase_cubit.dart';
 import '../../constants/colors.dart' as colors;
 import '../../constants/sizes.dart';
 import '../showcase/showcase_item.dart';
+import './components/toolbar_actions.dart';
 import 'components/location_search.dart';
 import 'components/scanning_state_icons.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -1028,10 +1028,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.3.0"
   win32:
     dependency: transitive
     description:
@@ -1065,5 +1065,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.2.4 <4.0.0"
+  flutter: ">=3.16.7"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,12 +5,12 @@ description: >
   4709-002 standards
 repository: https://github.com/dronetag/drone-scanner
 issue_tracker: https://github.com/dronetag/drone-scanner/issues
-version: 1.5.2
+version: 1.6.0
 
 publish_to: none
 environment:
-  sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.10.0"
+  sdk: ">=3.2.4 <4.0.0"
+  flutter: ">=3.16.7"
 
 # # Uncomment to use flutter_opendroneid from local repository
 # dependency_overrides:


### PR DESCRIPTION
Update flutter to 3.16. I mostly mimicked what was done in other repos.

I also solved the issue with `textScaleFactor` being deprecated. There is also another deprecation of `WillPopScope` that does not seem so trivial so I created an issue for it: [DT-2953](https://dronetag.atlassian.net/browse/DT-2953)

[DT-2953]: https://dronetag.atlassian.net/browse/DT-2953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ