### PR TITLE
fix: handle ornithology service not recognizing aircraft

### DIFF
--- a/lib/bloc/aircraft/aircraft_cubit.dart
+++ b/lib/bloc/aircraft/aircraft_cubit.dart
@@ -166,6 +166,11 @@ class AircraftCubit extends Cubit<AircraftState> {
       emit(state.copyWith(fetchInProgress: true));
       final modelInfo = await ornithologyRestClient.fetchAircraftModelInfo(
           serialNumber: serialNumber);
+      if (modelInfo == null) {
+        Logger.root.warning('Aircraft model info for $serialNumber is unknown');
+        emit(state.copyWith(fetchInProgress: false));
+        return;
+      }
       emit(
         state.copyWith(aircraftModelInfo: {
           ...state.aircraftModelInfo,

--- a/lib/services/ornithology_rest_client.dart
+++ b/lib/services/ornithology_rest_client.dart
@@ -6,13 +6,15 @@ const ornitologyRestApiEndpoint = 'https://ornithology.dronetag.app';
 class OrnithologyRestClient extends RestClient {
   OrnithologyRestClient() : super(Uri.parse(ornitologyRestApiEndpoint));
 
-  Future<AircraftModelInfo> fetchAircraftModelInfo(
+  Future<AircraftModelInfo?> fetchAircraftModelInfo(
       {required String serialNumber}) async {
     final response = await super.request(
       HttpMethod.get,
       query: {'serial_number': serialNumber},
       '/',
     );
+
+    if (response.statusCode != 200) return null;
 
     return convertToObject(
       response,


### PR DESCRIPTION
App did not handle cases when ornithology did not recognize the aircraft and returned `404 - Aircraft not found`. If this happened, the progress indicators on aircraft detail kept spinning. This can be seen e.g. with Japanese devices.

Return `null` from ornithology client when aircraft is not found.