### PR TITLE
feat: handle multiple basic id messages

### DIFF
--- a/lib/bloc/aircraft/aircraft_cubit.dart
+++ b/lib/bloc/aircraft/aircraft_cubit.dart
@@ -57,12 +57,14 @@ class AircraftCubit extends Cubit<AircraftState> {
         baroAltitudeAccuracy: VerticalAccuracy.meters_150,
         timestampAccuracy: null,
       ),
-      basicIdMessage: BasicIDMessage(
-        protocolVersion: 1,
-        uasID: SerialNumber(serialNumber: '52426900931WDHW83'),
-        rawContent: Uint8List(0),
-        uaType: UAType.helicopterOrMultirotor,
-      ),
+      basicIdMessages: {
+        IDType.serialNumber: BasicIDMessage(
+          protocolVersion: 1,
+          uasID: SerialNumber(serialNumber: '52426900931WDHW83'),
+          rawContent: Uint8List(0),
+          uaType: UAType.helicopterOrMultirotor,
+        ),
+      },
       operatorIdMessage: OperatorIDMessage(
         protocolVersion: 1,
         operatorID: 'FIN87astrdge12k8-xyz',
@@ -220,7 +222,8 @@ class AircraftCubit extends Cubit<AircraftState> {
   MessageContainer? findByUasID(String uasId) {
     final packs = state.packHistory().values.firstWhere(
         (packList) => packList.any(
-            (element) => element.basicIdMessage?.uasID.asString() == uasId),
+              (element) => element.containsUasId(uasId),
+            ),
         orElse: () => []);
     return packs.isEmpty ? null : packs.last;
   }

--- a/lib/bloc/aircraft/aircraft_state.dart
+++ b/lib/bloc/aircraft/aircraft_state.dart
@@ -45,15 +45,18 @@ class AircraftState {
         _packHistory.entries.toList()
           ..sort(
             (e1, e2) {
-              if (e1.value.last.basicIdMessage?.uasID.asString() == null) {
+              if (e1.value.last.preferredBasicIdMessage?.uasID.asString() ==
+                  null) {
                 return 1;
               }
-              if (e2.value.last.basicIdMessage?.uasID.asString() == null) {
+              if (e2.value.last.preferredBasicIdMessage?.uasID.asString() ==
+                  null) {
                 return -1;
               }
-              return e1.value.last.basicIdMessage!.uasID
+              return e1.value.last.preferredBasicIdMessage!.uasID
                   .toString()
-                  .compareTo(e2.value.last.basicIdMessage!.uasID.asString()!);
+                  .compareTo(
+                      e2.value.last.preferredBasicIdMessage!.uasID.asString()!);
             },
           ),
       ),
@@ -103,12 +106,10 @@ class AircraftState {
     if (myDronePositioning != null &&
         myDronePositioning != MyDronePositioning.defaultPosition &&
         userAircraftUasId != null &&
-        aircraft.values.any((e) =>
-            e.first.basicIdMessage?.uasID.asString() == userAircraftUasId)) {
+        aircraft.values.any((e) => e.last.containsUasId(userAircraftUasId))) {
       final entryList = aircraft.entries.toList();
-      final priorityData = entryList.firstWhere((element) =>
-          element.value.last.basicIdMessage?.uasID.asString() ==
-          userAircraftUasId);
+      final priorityData = entryList.firstWhere(
+          (element) => element.value.last.containsUasId(userAircraftUasId));
       entryList.remove(priorityData);
       entryList.insert(
         myDronePositioning == MyDronePositioning.alwaysFirst

--- a/lib/bloc/aircraft/export_cubit.dart
+++ b/lib/bloc/aircraft/export_cubit.dart
@@ -92,14 +92,14 @@ class ExportCubit extends Cubit<ExportState> {
         aircraftState
                 .packHistory()[mac]
                 ?.last
-                .basicIdMessage
+                .preferredBasicIdMessage
                 ?.uasID
                 .asString() !=
             null) {
       filename = aircraftState
           .packHistory()[mac]!
           .last
-          .basicIdMessage!
+          .preferredBasicIdMessage!
           .uasID
           .asString()!;
     } else {

--- a/lib/bloc/map/map_cubit.dart
+++ b/lib/bloc/map/map_cubit.dart
@@ -284,8 +284,7 @@ class MapCubit extends Cubit<GMapState> {
                   if (selItemMac != null && e.last.macAddress == selItemMac) {
                     markerHue = gmap.BitmapDescriptor.hueRed;
                   } else if (userAircraftUasId != null &&
-                      e.last.basicIdMessage?.uasID.asString() ==
-                          userAircraftUasId) {
+                      e.last.containsUasId(userAircraftUasId)) {
                     markerHue = 110;
                   } else if (e.last.locationMessage == null ||
                       e.last.locationMessage?.status ==
@@ -295,8 +294,8 @@ class MapCubit extends Cubit<GMapState> {
                     markerHue = gmap.BitmapDescriptor.hueBlue;
                   }
                   var haslocation = (e.isNotEmpty && e.last.locationValid);
-                  final uasIdText = e.last.basicIdMessage != null
-                      ? e.last.basicIdMessage?.uasID.asString()
+                  final uasIdText = e.last.preferredBasicIdMessage != null
+                      ? e.last.preferredBasicIdMessage?.uasID.asString()
                       : 'Unknown UAS ID';
                   final givenLabel = context
                       .read<AircraftCubit>()

--- a/lib/utils/csvlogger.dart
+++ b/lib/utils/csvlogger.dart
@@ -203,10 +203,12 @@ class CSVLogger {
       row.addAll(_logLocationMessage(container.locationMessage!));
       csvData.add(row);
     }
-    if (container.basicIdMessage != null) {
-      final row = logMetadata(container, 'Basic ID');
-      row.addAll(_logBasicMessage(container.basicIdMessage!));
-      csvData.add(row);
+    if (container.basicIdMessages != null) {
+      for (final basicIdMessage in container.basicIdMessages!.values) {
+        final row = logMetadata(container, 'Basic ID');
+        row.addAll(_logBasicMessage(basicIdMessage));
+        csvData.add(row);
+      }
     }
     if (container.operatorIdMessage != null) {
       final row = logMetadata(container, 'Operator ID');

--- a/lib/widgets/preferences/components/users_device_uas_id_text_field.dart
+++ b/lib/widgets/preferences/components/users_device_uas_id_text_field.dart
@@ -87,7 +87,7 @@ class _UsersDeviceUASIDTextFieldState extends State<UsersDeviceUASIDTextField> {
                 child: TextField(
                   decoration: const InputDecoration(
                     border: OutlineInputBorder(),
-                    hintText: 'UAS ID',
+                    hintText: 'Serial Number',
                   ),
                   controller: _controller,
                   onSubmitted: (_) => _submit(context),

--- a/lib/widgets/sliders/aircraft/aircraft_actions.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_actions.dart
@@ -114,8 +114,13 @@ void handleAction(BuildContext context, AircraftAction action) {
         context,
         'Are you sure you want to delete aircraft data?',
         () {
-          context.read<ProximityAlertsCubit>().clearFoundDrone(
-              messagePackList.last.basicIdMessage?.uasID.asString());
+          final alertsCubit = context.read<ProximityAlertsCubit>();
+          if (messagePackList.last.basicIdMessages != null) {
+            for (final basicIdMessage
+                in messagePackList.last.basicIdMessages!.values) {
+              alertsCubit.clearFoundDrone(basicIdMessage.uasID.asString());
+            }
+          }
           context.read<SlidersCubit>().setShowDroneDetail(show: false);
           context.read<AircraftCubit>().deletePack(selectedMac);
           context.read<SelectedAircraftCubit>().unselectAircraft();

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -43,10 +43,8 @@ class AircraftCard extends StatelessWidget {
         messagePack.operatorIDValid) {
       flag = getFlag(countryCode);
     }
-    final uasIdText = messagePack.basicIdMessage != null &&
-            messagePack.basicIdMessage?.uasID.asString() != null
-        ? messagePack.basicIdMessage!.uasID.asString()!
-        : 'Unknown UAS ID';
+    final uasId = messagePack.preferredBasicIdMessage?.uasID;
+    final uasIdText = uasId?.asString() ?? 'Unknown UAS ID';
     final opIdTrimmed =
         messagePack.operatorIdMessage?.operatorID.removeNonAlphanumeric();
     final opIdText = messagePack.operatorIDSet
@@ -112,10 +110,11 @@ class AircraftCard extends StatelessWidget {
   Widget buildLeading(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     final status = messagePack.locationMessage?.status;
-    final proximityAlertsActive = context
-        .read<ProximityAlertsCubit>()
-        .state
-        .isAlertActiveForId(messagePack.basicIdMessage?.uasID.asString());
+    final proximityAlertsState = context.read<ProximityAlertsCubit>().state;
+    final proximityAlertsActive = messagePack.basicIdMessages?.values.any(
+            (element) => proximityAlertsState
+                .isAlertActiveForId(element.uasID.asString())) ??
+        false;
 
     final icon = status == OperationalStatus.none
         ? null
@@ -163,10 +162,8 @@ class AircraftCard extends StatelessWidget {
   }
 
   Widget buildTrailing(BuildContext context) {
-    if (messagePack.basicIdMessage != null &&
-        messagePack.basicIdMessage?.uaType != null) {
-      // to-do: icon according to basic.uaType
-    }
+    // TODO: icon according to basic.uaType
+
     final rssi = messagePack.lastMessageRssi;
     final source = messagePack.packSource;
     final standardText = getSourceShortcut(source);

--- a/lib/widgets/sliders/aircraft/detail/aircraft_detail.dart
+++ b/lib/widgets/sliders/aircraft/detail/aircraft_detail.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_opendroneid/models/message_container.dart';
-import 'package:flutter_opendroneid/utils/conversions.dart';
 
 import '../../../../bloc/aircraft/aircraft_cubit.dart';
 import '../../../../bloc/aircraft/selected_aircraft_cubit.dart';
@@ -35,14 +34,8 @@ class _AircraftDetailState extends State<AircraftDetail> {
     if (selectedMac == null) return;
     setState(
       () {
-        // check if model info for current aircraft exists and fetch if not
-        uasId = context
-            .read<AircraftCubit>()
-            .findByMacAddress(selectedMac)
-            ?.basicIdMessage
-            ?.uasID
-            .asString();
-
+        final aircraftCubit = context.read<AircraftCubit>();
+        uasId = aircraftCubit.findByMacAddress(selectedMac)?.serialNumberUasId;
         if (uasId == null) return;
 
         final modelInfo =

--- a/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
+++ b/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
@@ -135,7 +135,8 @@ class AircraftDetailHeader extends StatelessWidget {
               children: [
                 buildTitle(
                   context,
-                  messagePackList.last.basicIdMessage?.uasID.asString(),
+                  messagePackList.last.preferredBasicIdMessage?.uasID
+                      .asString(),
                 ),
                 if (messagePackList.last.operatorIDSet)
                   buildSubtitle(context, messagePackList),

--- a/lib/widgets/sliders/aircraft/detail/set_as_mine_button.dart
+++ b/lib/widgets/sliders/aircraft/detail/set_as_mine_button.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_opendroneid/flutter_opendroneid.dart';
+import 'package:flutter_opendroneid/utils/conversions.dart';
+
+import '../../../../bloc/proximity_alerts_cubit.dart';
+import '../../../../constants/colors.dart';
+import '../../../../constants/sizes.dart';
+import '../../../../utils/utils.dart';
+import '../../../app/dialogs.dart';
+
+class SetAsMineButton extends StatelessWidget {
+  const SetAsMineButton({
+    super.key,
+    required this.uasId,
+    required this.proximityAlertsActive,
+  });
+
+  final UASID? uasId;
+  final bool proximityAlertsActive;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: () {
+        final alertsCubit = context.read<ProximityAlertsCubit>();
+        if (uasId?.asString() != null &&
+            alertsCubit.state.usersAircraftUASID == uasId!.asString()) {
+          alertsCubit.clearUsersAircraftUASID();
+          showSnackBar(context, 'Owned aircaft was unset');
+        } else {
+          if (uasId?.asString() == null) {
+            showSnackBar(
+                context, 'Cannot set aircraft as owned: Unknown UAS ID');
+            return;
+          }
+          if (uasId?.type == IDType.serialNumber) {
+            final validationError = validateUASID(uasId!.asString()!);
+            if (validationError != null) {
+              showSnackBar(context, 'Error parsing UAS ID: $validationError');
+              FocusManager.instance.primaryFocus?.unfocus();
+              return;
+            }
+          }
+          alertsCubit.setUsersAircraftUASID(uasId!.asString()!);
+          showSnackBar(context, 'Aircaft set as owned');
+        }
+      },
+      style: ButtonStyle(
+        backgroundColor: MaterialStateProperty.all<Color>(
+          proximityAlertsActive ? AppColors.green : Colors.white,
+        ),
+        side: MaterialStateProperty.all<BorderSide>(
+          BorderSide(
+              width: 2.0,
+              color: proximityAlertsActive ? Colors.white : AppColors.green),
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: EdgeInsets.only(
+              right: proximityAlertsActive ? 0 : Sizes.iconPadding,
+            ),
+            child: Icon(
+              Icons.person,
+              size: Sizes.iconSize,
+              color: proximityAlertsActive ? Colors.white : AppColors.green,
+            ),
+          ),
+          if (proximityAlertsActive)
+            const Padding(
+              padding: EdgeInsets.only(right: Sizes.iconPadding),
+              child: Icon(
+                Icons.done,
+                color: Colors.white,
+                size: Sizes.iconSize * 0.75,
+              ),
+            ),
+          Text(
+            proximityAlertsActive ? 'MINE' : 'SET AS MINE',
+            style: TextStyle(
+                fontSize: 12,
+                color: proximityAlertsActive ? Colors.white : AppColors.green),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/sliders/common/headline.dart
+++ b/lib/widgets/sliders/common/headline.dart
@@ -9,6 +9,7 @@ class Headline extends StatelessWidget {
   final Widget? leading;
   final Color? color;
   final double? fontSize;
+  final double dividerThickness;
 
   const Headline({
     super.key,
@@ -17,6 +18,7 @@ class Headline extends StatelessWidget {
     this.leading,
     this.color,
     this.fontSize,
+    this.dividerThickness = 2,
   });
 
   @override
@@ -46,9 +48,9 @@ class Headline extends StatelessWidget {
           const SizedBox(
             width: 20,
           ),
-          const Expanded(
+          Expanded(
             child: Divider(
-              thickness: 2,
+              thickness: dividerThickness,
               color: AppColors.lightGray,
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,10 +298,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_opendroneid
-      sha256: "034236de38697427793c04fc20326b8b51b62d07388058fc74f68ef2be990861"
+      sha256: b3ed2fafa474d0bad0eded4e8516c0524ccf33ba1a966f6d696e3765cce4c0bf
       url: "https://pub.dev"
     source: hosted
-    version: "0.16.0"
+    version: "0.17.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_opendroneid: ^0.16.0
+  flutter_opendroneid: ^0.17.0
   flutter_local_notifications: ^14.0.0
   another_flushbar: ^1.12.30
   sprintf: ^7.0.0


### PR DESCRIPTION
Handle multiple basic id messages with different types of UAS ID.

Show multiple UAS IDs in aircraft detail. In other places like card, map, proximity alerts show preferred UAS ID, which is of `SerialNumber` type if such id exists.

Depends on https://github.com/dronetag/flutter-opendroneid/pull/28.

<img src="https://github.com/dronetag/drone-scanner/assets/15686037/4fa6b0fa-b469-442f-87e8-a42cb9d474e9" width="250">



DT-2987