### PR TITLE
chore: bump macos version in delivery workflow

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -53,7 +53,7 @@ jobs:
     needs:
       - release-version
       - start-deployment
-    runs-on: macos-12
+    runs-on: macos-14
     timeout-minutes: 20
     env:
       FLUTTER_BUILD_NAME: ${{ needs.release-version.outputs.version }}


### PR DESCRIPTION
In our delivery workflow we used [macos-12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md). It has Xcode 14.2 and iOS SDK 16.2 installed.

Switch to [macos-14](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md) which has Xcode 15.0.1 and iOS SDK 17.2.

Also changed in https://github.com/dronetag/app/pull/362 and https://github.com/dronetag/toolbox/pull/65.

DT-3007