### PR TITLE
Migrated from `WillPopScope` to `PopScope`

### DIFF
--- a/lib/bloc/map/map_cubit.dart
+++ b/lib/bloc/map/map_cubit.dart
@@ -327,7 +327,7 @@ class MapCubit extends Cubit<GMapState> {
                       context
                           .read<SlidersCubit>()
                           .setShowDroneDetail(show: true);
-                      if (context.read<SlidersCubit>().isPanelClosed()) {
+                      if (context.read<SlidersCubit>().isPanelClosed) {
                         context.read<SlidersCubit>().animatePanelToSnapPoint();
                       }
                     },

--- a/lib/bloc/sliders_cubit.dart
+++ b/lib/bloc/sliders_cubit.dart
@@ -122,12 +122,12 @@ class SlidersCubit extends Cubit<SlidersState> {
     );
   }
 
-  bool isPanelClosed() {
+  bool get isPanelClosed {
     return panelController.state != null &&
         panelController.state!.extent == bottomSnap;
   }
 
-  bool isPanelOpened() {
+  bool get isPanelOpened {
     return panelController.state != null &&
         panelController.state!.extent == topSnap;
   }

--- a/lib/widgets/app/proximity_alert_snackbar.dart
+++ b/lib/widgets/app/proximity_alert_snackbar.dart
@@ -194,7 +194,7 @@ class _ProximityAlertSnackbarState extends State<ProximityAlertSnackbar>
                                       .setShowDroneDetail(show: true);
                                   if (context
                                       .read<SlidersCubit>()
-                                      .isPanelClosed()) {
+                                      .isPanelClosed) {
                                     context
                                         .read<SlidersCubit>()
                                         .animatePanelToSnapPoint();

--- a/lib/widgets/mainpage/home_page.dart
+++ b/lib/widgets/mainpage/home_page.dart
@@ -28,26 +28,37 @@ class MyHomePage extends StatelessWidget {
           context.read<ShowcaseCubit>().onShowcaseFinish(context);
         },
         builder: Builder(
-          builder: (context) => AnnotatedRegion(
-            value: SystemUiOverlayStyle.dark,
-            child: WillPopScope(
-              onWillPop: () async {
-                final cubit = context.read<SlidersCubit>();
-                final state = cubit.state;
-                if (state.showDroneDetail) {
-                  await cubit.setShowDroneDetail(show: false);
-                  return false;
-                } else if (cubit.isPanelOpened()) {
-                  await context.read<SlidersCubit>().animatePanelToSnapPoint();
-                  return false;
-                }
-                return true;
-              },
-              child: const AppScaffold(
-                child: HomeBody(),
+          builder: (context) {
+            final showDroneDetail = context.select<SlidersCubit, bool>(
+                (cubit) => cubit.state.showDroneDetail);
+            final isPanelOpened = context
+                .select<SlidersCubit, bool>((cubit) => cubit.isPanelOpened);
+
+            return AnnotatedRegion(
+              value: SystemUiOverlayStyle.dark,
+              child: PopScope(
+                canPop: !showDroneDetail && !isPanelOpened,
+                onPopInvoked: (_) async {
+                  if (showDroneDetail) {
+                    await context
+                        .read<SlidersCubit>()
+                        .setShowDroneDetail(show: false);
+                    return;
+                  }
+
+                  if (isPanelOpened) {
+                    await context
+                        .read<SlidersCubit>()
+                        .animatePanelToSnapPoint();
+                    return;
+                  }
+                },
+                child: const AppScaffold(
+                  child: HomeBody(),
+                ),
               ),
-            ),
-          ),
+            );
+          },
         ),
       ),
     );

--- a/lib/widgets/sliders/aircraft/aircraft_actions.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_actions.dart
@@ -87,7 +87,7 @@ Future<AircraftAction?> displayAircraftActionMenu(BuildContext context) async {
     ],
     position: RelativeRect.fromLTRB(
       MediaQuery.of(context).size.width,
-      context.read<SlidersCubit>().isPanelOpened()
+      context.read<SlidersCubit>().isPanelOpened
           ? MediaQuery.of(context).size.height / 6
           : MediaQuery.of(context).size.height / 4 * 3,
       Sizes.screenSpacing,

--- a/lib/widgets/sliders/airspace_sliding_panel.dart
+++ b/lib/widgets/sliders/airspace_sliding_panel.dart
@@ -31,7 +31,7 @@ class _AircraftSlidingPanelState extends State<AirspaceSlidingPanel>
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    final sliderMaximized = context.watch<SlidersCubit>().isPanelOpened();
+    final sliderMaximized = context.watch<SlidersCubit>().isPanelOpened;
     final borderRadius = sliderMaximized ? 0.0 : 10.0;
     return BlocBuilder<SlidersCubit, SlidersState>(
       builder: (context, state) {
@@ -102,14 +102,14 @@ class _AircraftSlidingPanelState extends State<AirspaceSlidingPanel>
 
   void onHeaderTapPortrait() {
     final cubit = context.read<SlidersCubit>();
-    if (cubit.isPanelClosed() || cubit.isPanelOpened()) {
+    if (cubit.isPanelClosed || cubit.isPanelOpened) {
       cubit.animatePanelToSnapPoint();
     }
   }
 
   void onHeaderTapLandscape() {
     final cubit = context.read<SlidersCubit>();
-    if (cubit.isPanelClosed()) {
+    if (cubit.isPanelClosed) {
       cubit.openSlider();
     } else {
       cubit.closeSlider();

--- a/lib/widgets/sliders/common/airspace_list_header.dart
+++ b/lib/widgets/sliders/common/airspace_list_header.dart
@@ -95,7 +95,7 @@ class AirspaceListHeader extends StatelessWidget {
                         ],
                       ),
                     ),*/
-                  if (!context.read<SlidersCubit>().isPanelClosed())
+                  if (!context.read<SlidersCubit>().isPanelClosed)
                     Row(
                       children: [
                         const SizedBox(),

--- a/lib/widgets/sliders/sheet/sheet.dart
+++ b/lib/widgets/sliders/sheet/sheet.dart
@@ -326,6 +326,7 @@ class _SlidingSheetState extends State<SlidingSheet>
   final GlobalKey footerKey = GlobalKey();
 
   bool get hasHeader => widget.headerBuilder != null;
+
   bool get hasFooter => widget.footerBuilder != null;
 
   late List<double> snappings;
@@ -337,9 +338,11 @@ class _SlidingSheetState extends State<SlidingSheet>
 
   // Whether the dialog completed its initial fly in
   bool didCompleteInitialRoute = false;
+
   // Whether a dismiss was already triggered by the sheet itself
   // and thus further route pops can be safely ignored
   bool dismissUnderway = false;
+
   // Whether the drag on a delegating widget (such as the backdrop)
   // did start, when the sheet was not fully collapsed
   bool didStartDragWhenNotCollapsed = false;
@@ -351,6 +354,7 @@ class _SlidingSheetState extends State<SlidingSheet>
 
   // Whether the sheet has drawn its first frame.
   bool isLaidOut = false;
+
   // The total height of all sheet components.
   double get sheetHeight =>
       childHeight +
@@ -358,30 +362,43 @@ class _SlidingSheetState extends State<SlidingSheet>
       footerHeight +
       padding.vertical +
       borderHeight;
+
   // The maxiumum height that this sheet will cover.
   double get maxHeight => math.min(sheetHeight, availableHeight);
+
   bool get isScrollable => sheetHeight >= availableHeight;
 
   double get currentExtent =>
       (extent?.currentExtent ?? minExtent).clamp(0.0, 1.0);
+
   set currentExtent(double value) => extent?.currentExtent = value;
+
   double get headerExtent =>
       isLaidOut ? (headerHeight + (borderHeight / 2)) / availableHeight : 0.0;
+
   double get footerExtent =>
       isLaidOut ? (footerHeight + (borderHeight / 2)) / availableHeight : 0.0;
+
   double get headerFooterExtent => headerExtent + footerExtent;
+
   double get minExtent => snappings[isDialog ? 1 : 0].clamp(0.0, 1.0);
+
   double get maxExtent => snappings.last.clamp(0.0, 1.0);
+
   double get initialExtent => snapSpec.initialSnap != null
       ? _normalizeSnap(snapSpec.initialSnap!)
       : minExtent;
 
   bool get isDialog => widget.route != null;
+
   ScrollSpec get scrollSpec => widget.scrollSpec;
+
   SnapSpec get snapSpec => widget.snapSpec;
+
   SnapPositioning get snapPositioning => snapSpec.positioning;
 
   double get borderHeight => (widget.border?.top.width ?? 0) * 2;
+
   EdgeInsets get padding {
     final begin = widget.padding ?? const EdgeInsets.all(0);
 
@@ -806,22 +823,18 @@ class _SlidingSheetState extends State<SlidingSheet>
       return result;
     }
 
-    return WillPopScope(
-      onWillPop: () async {
-        if (isDialog) {
-          if (!widget.isDismissable) {
-            _onDismissPrevented(backButton: true);
-            return false;
-          } else {
-            return true;
-          }
-        } else {
-          if (!state.isCollapsed) {
-            await snapToExtent(minExtent);
-            return false;
-          } else {
-            return true;
-          }
+    return PopScope(
+      canPop: (isDialog && widget.isDismissable) ||
+          (!isDialog && state.isCollapsed),
+      onPopInvoked: (_) async {
+        if (isDialog && !widget.isDismissable) {
+          _onDismissPrevented(backButton: true);
+          return;
+        }
+
+        if (!isDialog && !state.isCollapsed) {
+          await snapToExtent(minExtent);
+          return;
         }
       },
       child: result,
@@ -1232,6 +1245,7 @@ class SheetState {
 
 class _InheritedSheetState extends InheritedWidget {
   final ValueNotifier<SheetState> state;
+
   const _InheritedSheetState(
     this.state,
     Widget child,
@@ -1312,6 +1326,7 @@ class SheetController {
 class Invisible extends StatelessWidget {
   final bool invisible;
   final Widget? child;
+
   const Invisible({
     super.key,
     this.invisible = false,

--- a/lib/widgets/toolbars/components/location_search.dart
+++ b/lib/widgets/toolbars/components/location_search.dart
@@ -57,7 +57,7 @@ class _LocationSearchState extends State<LocationSearch> {
       autocorrect: false,
       cursorColor: Colors.white,
       onTap: () {
-        if (context.read<SlidersCubit>().isPanelOpened()) {
+        if (context.read<SlidersCubit>().isPanelOpened) {
           context.read<SlidersCubit>().animatePanelToSnapPoint();
         }
         _autocomplete(context, textEditingController.text);
@@ -223,7 +223,7 @@ class _LocationSearchState extends State<LocationSearch> {
     await mapCubit.centerToLoc(location);
     await mapCubit.setDroppedPinLocation(location);
     await mapCubit.setDroppedPin(pinDropped: true);
-    if (slidersCubit.isPanelOpened()) {
+    if (slidersCubit.isPanelOpened) {
       await slidersCubit.animatePanelToSnapPoint();
     }
   }


### PR DESCRIPTION
Due to `WillPopScope` deprecation the widget code was migrated to the new `PopScope` widget which supports new Android predictive back.

Refactored `isPanelClosed()` and `isPanelOpened()` into getters.