### PR TITLE
chore: upgrade flutter to 3.22

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -5,7 +5,7 @@ name: Delivery
 # later published, for both iOS and Android platforms
 
 env:
-  FLUTTER_VERSION: "3.19.x"
+  FLUTTER_VERSION: "3.22.x"
   DEPLOYMENT_ENV_NAME: production
   IOS_BUNDLE_NAME: cz.dronetag.drone-scanner
   ANDROID_BUNDLE_NAME: cz.dronetag.dronescanner

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,7 +4,7 @@ name: Integration
 # and runs the unit test suite
 
 env:
-  FLUTTER_VERSION: "3.19.x"
+  FLUTTER_VERSION: "3.22.x"
 
 on:
   pull_request:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,9 +48,9 @@ android {
    
     defaultConfig {
         applicationId "cz.dronetag.dronescanner"
-        compileSdk 33
+        compileSdk 34
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 08 00:16:54 SGT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 08 00:16:54 SGT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -103,7 +103,7 @@ SPEC CHECKSUMS:
   google_maps_flutter_ios: c454f18e0e22df6ac0e9f2a4df340858f5a3680c
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
   location: d5cf8598915965547c3f36761ae9cc4f4e87d22e
-  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
+  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
   Sentry: cd86fc55628f5b7c572cabe66cc8f95a9d2f165a
@@ -111,7 +111,7 @@ SPEC CHECKSUMS:
   share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  wakelock_plus: 8b09852c8876491e4b6d179e17dfe2a0b5f60d47
+  wakelock_plus: 78ec7c5b202cab7761af8e2b2b3d0671be6c4ae1
 
 PODFILE CHECKSUM: a1259a7fc402ace8f6edaea2622af986625b8779
 

--- a/lib/widgets/mainpage/map_ui_google.dart
+++ b/lib/widgets/mainpage/map_ui_google.dart
@@ -43,7 +43,9 @@ class _MapUIGoogleState extends State<MapUIGoogle> with WidgetsBindingObserver {
 
   @override
   void dispose() {
-    context.read<MapCubit>().controller?.dispose();
+    if (mounted && context.mounted) {
+      context.read<MapCubit>().controller?.dispose();
+    }
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
@@ -200,9 +202,9 @@ class _MapUIGoogleState extends State<MapUIGoogle> with WidgetsBindingObserver {
 
   Future<void> onMapCreated(GoogleMapController controller) async {
     await _waitForMapReady(controller);
-    if (!mounted) return;
+    if (!mounted || !context.mounted) return;
     await context.read<MapCubit>().assignController(controller);
-    if (!mounted) return;
+    if (!mounted || !context.mounted) return;
     await context.read<MapCubit>().setMapStyle();
   }
 

--- a/lib/widgets/showcase/showcase_item.dart
+++ b/lib/widgets/showcase/showcase_item.dart
@@ -32,7 +32,7 @@ class ShowcaseItem extends StatelessWidget {
       width: MediaQuery.of(context).size.width - 20,
       height: 0,
       overlayOpacity: opacity ?? 0.75,
-      overlayPadding: padding ?? EdgeInsets.zero,
+      targetPadding: padding ?? EdgeInsets.zero,
       container: ShowcaseWidget(
         heading: title,
         text: description,

--- a/lib/widgets/showcase/showcase_root.dart
+++ b/lib/widgets/showcase/showcase_root.dart
@@ -20,7 +20,7 @@ class ShowcaseRoot extends StatelessWidget {
         top: 150.0 * context.read<ScreenCubit>().scaleHeight,
       ),
       child: Showcase.withWidget(
-        shapeBorder: const CircleBorder(),
+        targetShapeBorder: const CircleBorder(),
         width: MediaQuery.of(context).size.width,
         height: MediaQuery.of(context).size.height,
         container: ShowcaseStartWidget(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "61.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "5.13.0"
   another_flushbar:
     dependency: "direct main"
     description:
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+8"
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -314,10 +314,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_spinbox
-      sha256: c4a4a669f598145a582663970d309868174acf98c91d77ed7751dfb1c8e51ae3
+      sha256: "38d8c1a3a39f0fa72823d4470785f5e165f2deb53531ca7803b54ba45e4dbd46"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.13.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -407,10 +407,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -543,10 +543,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -591,18 +591,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "88bc797f44a94814f2213db1c9bd5badebafdfb8290ca9f78d4b9ee2a3db4d79"
+      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "8.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   path:
     dependency: transitive
     description:
@@ -887,10 +887,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -934,11 +934,12 @@ packages:
   showcaseview:
     dependency: "direct main"
     description:
-      name: showcaseview
-      sha256: "09b534d806572135c38e06901de4b36b2bbd61739ec56c5fa9242d10748e19df"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.8"
+      path: "."
+      ref: d1799034d6b6a61e5e173ae39416c24c1bccdfed
+      resolved-ref: d1799034d6b6a61e5e173ae39416c24c1bccdfed
+      url: "https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview.git"
+    source: git
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -1124,10 +1125,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1164,10 +1165,10 @@ packages:
     dependency: "direct main"
     description:
       name: wakelock_plus
-      sha256: f268ca2116db22e57577fb99d52515a24bdc1d570f12ac18bb762361d43b043d
+      sha256: "14758533319a462ffb5aa3b7ddb198e59b29ac3b02da14173a1715d65d4e6e68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.4"
+    version: "1.2.5"
   wakelock_plus_platform_interface:
     dependency: transitive
     description:
@@ -1188,18 +1189,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
+      sha256: "58c6666b342a38816b2e7e50ed0f1e261959630becd4c879c4f26bfa14aa5a42"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.5"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -1249,5 +1250,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.2"
+  dart: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,13 +9,21 @@ version: 1.6.0
 
 publish_to: none
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.2"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"
 
 # # Uncomment to use flutter_opendroneid from local repository
 # dependency_overrides:
 #   flutter_opendroneid:
 #     path: ../flutter-opendroneid
+
+# temporary override until https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview/pull/445
+# is merged
+dependency_overrides:
+  showcaseview:
+    git:
+      url: https://github.com/SimformSolutionsPvtLtd/flutter_showcaseview.git
+      ref: d1799034d6b6a61e5e173ae39416c24c1bccdfed
 
 dependencies:
   flutter:
@@ -28,9 +36,9 @@ dependencies:
   location: ^5.0.3
   http: ^1.2.0
   permission_handler: ^11.2.0
-  flutter_spinbox: ^0.8.0
+  flutter_spinbox: ^0.13.1
   path_provider: ^2.0.9
-  showcaseview: ^1.1.7
+  showcaseview: ^2.1.0
   shared_preferences: ^2.0.13
   device_info_plus: ^9.1.2
   timer_builder: ^2.0.0
@@ -38,12 +46,12 @@ dependencies:
   app_settings: ^5.1.1
   share_plus: ^7.2.2
   flutter_bloc: ^8.0.1
-  package_info_plus: ^5.0.1
+  package_info_plus: ^8.0.0
   localstorage: ^4.0.0+1
   sentry_flutter: ^7.9.0
   rxdart: ^0.27.5
   vector_math: ^2.1.2
-  wakelock_plus: ^1.1.4
+  wakelock_plus: ^1.2.0
   scrollable_positioned_list: ^0.3.5
   flutter_markdown: ^0.6.13
   url_launcher: ^6.1.6


### PR DESCRIPTION
Upgrade flutter to 3.22

Upgrade packages and fix breaking changes. 
Showcaseview is not yet compatible on master so I used commit which fixes it from it's repo. I also had to upgrade flutter_spinbox, wakelock, package_info_plus. Then there were issues with Java and gradle compatibility, which I solved by installing the newest Android studio and bumping compileSdk in build.gradle.