### PR TITLE
fix: app crashing on pixel 8 with android 14 

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -83,5 +83,7 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
 }


### PR DESCRIPTION
As Lukas [reported on slack](https://getdronetag.slack.com/archives/C02N11D6D5J/p1716997963316389), the app crashed on startup on Pixel 8 with Android 14.

Fix crash by adding _WindowManager_ dependency to _build.gradle._

Crash was actually caused by `flutter_local_notifications` package or as they claim it's a Flutter [issue](https://github.com/flutter/flutter/issues/110658). I found the fix in package's [readme](https://pub.dev/packages/flutter_local_notifications#-android-setup).

Tested app startup on virtual pixel 8 with sdk lvl 34. I also sent the app to lukas to see if it fixed the issue on a real device.