### PR TITLE
feat: positive spoofer detectors

### DIFF
--- a/lib/bloc/aircraft/aircraft_cubit.dart
+++ b/lib/bloc/aircraft/aircraft_cubit.dart
@@ -20,6 +20,8 @@ class AircraftCubit extends Cubit<AircraftState> {
   Timer? _refreshTimer;
   final AircraftExpirationCubit expirationCubit;
 
+  final MessageContainerAuthenticator messageContainerAuthenticator;
+
   static const uiUpdateIntervalMs = 200;
 
   // data for showcase
@@ -71,8 +73,10 @@ class AircraftCubit extends Cubit<AircraftState> {
     ),
   ];
 
-  AircraftCubit({required this.expirationCubit})
-      : super(AircraftState(packHistory: {}, dataAuthenticityStatuses: {})) {
+  AircraftCubit({
+    required this.expirationCubit,
+    required this.messageContainerAuthenticator,
+  }) : super(AircraftState(packHistory: {}, dataAuthenticityStatuses: {})) {
     expirationCubit.deleteCallback = deletePack;
   }
 
@@ -147,7 +151,7 @@ class AircraftCubit extends Cubit<AircraftState> {
           dataAuthenticityStatuses: state.dataAuthenticityStatuses
             ..addAll({
               pack.macAddress:
-                  MessageContainerAuthenticator.determineAuthenticityStatus(
+                  messageContainerAuthenticator.determineAuthenticityStatus(
                 pack,
               )
             }),

--- a/lib/exceptions/invalid_country_code_exception.dart
+++ b/lib/exceptions/invalid_country_code_exception.dart
@@ -1,0 +1,5 @@
+class InvalidCountryCodeException implements Exception {
+  final String message;
+
+  InvalidCountryCodeException([this.message = "Invalid country code"]);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,6 +28,7 @@ import 'services/geocoding_rest_client.dart';
 import 'services/location_service.dart';
 import 'services/notification_service.dart';
 import 'services/ornithology_rest_client.dart';
+import 'utils/message_container_authenticator.dart';
 import 'widgets/app/app.dart';
 
 const sentryDsn = String.fromEnvironment(
@@ -68,13 +69,19 @@ void main() async {
   // init local notifications
   final notificationService = NotificationService();
   await notificationService.setup();
-  // Init Google services
+  // init location services
   final locationService = LocationService();
+
+  await locationService.enableService();
+
   final mapCubit = MapCubit(locationService);
+  final messageContainerAuthenticator =
+      MessageContainerAuthenticator(locationService: locationService);
   final selectedCubit = SelectedAircraftCubit();
   final aircraftExpirationCubit = AircraftExpirationCubit();
   final aircraftCubit = AircraftCubit(
     expirationCubit: aircraftExpirationCubit,
+    messageContainerAuthenticator: messageContainerAuthenticator,
   );
   final aircraftMetadataCubit = await AircraftMetadataCubit(
           ornithologyRestClient: OrnithologyRestClient(),

--- a/lib/models/message_container_authenticity_status.dart
+++ b/lib/models/message_container_authenticity_status.dart
@@ -9,13 +9,3 @@ enum MessageContainerAuthenticityStatus {
   // high certainty of falsehood
   counterfeit
 }
-
-// only suspicious and counterfeit statuses are displayed in UI,
-// temporary measure until verification is complete
-extension MessageContainerAuthenticityStatusExtension
-    on MessageContainerAuthenticityStatus {
-  bool get shouldBeDisplayed {
-    return this == MessageContainerAuthenticityStatus.suspicious ||
-        this == MessageContainerAuthenticityStatus.counterfeit;
-  }
-}

--- a/lib/models/message_container_authenticity_status.dart
+++ b/lib/models/message_container_authenticity_status.dart
@@ -2,9 +2,11 @@
 enum MessageContainerAuthenticityStatus {
   // verified by authority/multilateration
   verified,
+  // reasonable signs of authenticity exist
+  trusted,
   // default
   untrusted,
-  // signs if questionable authenticity exist
+  // signs of questionable authenticity exist
   suspicious,
   // high certainty of falsehood
   counterfeit

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -22,6 +22,10 @@ class LocationService {
   bool settingsSet = false;
   loc.PermissionStatus permissions = loc.PermissionStatus.denied;
 
+  LocationService() {
+    location.onLocationChanged.listen(_onLocationUpdated);
+  }
+
   bool get missingGrantedPermission =>
       permissions != loc.PermissionStatus.granted;
 
@@ -79,11 +83,17 @@ class LocationService {
 
     final locationData = await location.getLocation();
 
+    _onLocationUpdated(locationData);
+
+    return lastLocation;
+  }
+
+  void _onLocationUpdated(locationData) {
     if (locationData.latitude == null || locationData.longitude == null) {
-      return null;
+      return;
     }
 
-    return lastLocation = Location(
+    lastLocation = Location(
       latitude: locationData.latitude!,
       longitude: locationData.longitude!,
     );

--- a/lib/utils/message_container_authenticator.dart
+++ b/lib/utils/message_container_authenticator.dart
@@ -50,13 +50,13 @@ class MessageContainerAuthenticator {
 
     // if nothing can be decided, score is exactly half, when score is bigger
     // than half, at least one detector noticed suspisious data.
-    // Score bellow 1/4 is considered verified.
+    // Score bellow 1/4 is considered trusted.
     final untrustedScore = maxScore * 0.25;
     final noSuspisionScore = maxScore * 0.5;
     final counterfeitScore = maxScore * 0.75;
 
     if (score <= untrustedScore) {
-      return MessageContainerAuthenticityStatus.verified;
+      return MessageContainerAuthenticityStatus.trusted;
     }
     if (score <= noSuspisionScore) {
       return MessageContainerAuthenticityStatus.untrusted;

--- a/lib/widgets/sliders/aircraft/aircraft_card.dart
+++ b/lib/widgets/sliders/aircraft/aircraft_card.dart
@@ -236,11 +236,11 @@ class AircraftCard extends StatelessWidget {
         AircraftCardCustomText(
           messagePack: messagePack,
         ),
-        if (authenticityStatus.shouldBeDisplayed)
-          Text(
-            authenticityStatus.name.capitalize(),
-            textScaler: const TextScaler.linear(0.9),
-          )
+
+        Text(
+          authenticityStatus.name.capitalize(),
+          textScaler: const TextScaler.linear(0.9),
+        )
       ],
     );
   }

--- a/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
+++ b/lib/widgets/sliders/aircraft/detail/aircraft_detail_header.dart
@@ -307,14 +307,12 @@ class AircraftDetailHeader extends StatelessWidget {
           cubit.state.dataAuthenticityStatuses[macAddress] ??
           MessageContainerAuthenticityStatus.untrusted,
     );
-    if (authenticityStatus.shouldBeDisplayed) {
-      return Text(
-        authenticityStatus.name.capitalize(),
-        style: const TextStyle(
-          color: Colors.white,
-        ),
-      );
-    }
-    return const SizedBox.shrink();
+
+    return Text(
+      authenticityStatus.name.capitalize(),
+      style: const TextStyle(
+        color: Colors.white,
+      ),
+    );
   }
 }

--- a/lib/widgets/sliders/common/flag.dart
+++ b/lib/widgets/sliders/common/flag.dart
@@ -43,7 +43,7 @@ class _FlagState extends State<Flag> {
         }
         if (state.fetchInProgress) {
           return SmallCircularProgressIndicator(
-            size: Sizes.standard / 10,
+            size: Sizes.standard,
             color: widget.color,
             margin: const EdgeInsets.all(
               Sizes.standard / 3,


### PR DESCRIPTION
Add 2 new detectors: `LocationTimestampSpooferDetector` and `LocationSpooferDetector`. Show all data authenticity statuses in app UI.

`LocationSpooferDetector` compares phone location with the aircraft location and returns spoofed probability based on distance. If the distance is 3000-10000 meters, data are considered suspicious (probability of being spoofed is 0.75). If the distance is bigger than 10000 meters, data are considered counterfeit (probability 1). Since the spoofer has configurable location, it is possible that data are spoofed even when distance to phone is smaller.

`LocationTimestampSpooferDetector` compares timestamp from location message with the system time.  I used bit more strict thresholds than were written in the task. If the difference is btw 10-60 seconds, data are considered suspicious (probability is 0.75). If the difference is more than 60 seconds, data are considered counterfeit (probability 1). If the difference is small, there is still small chance data are spoofed, because loc timestamp is only the duration from last full hour. The spoofer may have been started exactly at the time that lines up with start of full hour.

Dronetag devices are now marked as _verified_ as long as they have real location data. Devices with simulated data are still _untrusted_. Spoofed devices are _counterfeit_ when all messages are received. Check screenshots with all the mentioned situations.

| Dronetag with simulated/real location|spoofed with/without location| 
|--|--|
| <img width="336" alt="Screenshot 2024-06-04 at 21 16 54" src="https://github.com/dronetag/drone-scanner/assets/15686037/9967aa40-b99e-4065-bfcb-e70752aa86a2">|<img width="336" alt="Screenshot 2024-06-04 at 21 16 47" src="https://github.com/dronetag/drone-scanner/assets/15686037/8224873c-0c91-4cf6-abfb-f5d9536d57fe">|

Location is required for bt scanning on recent androids. On iOS, it is possible to scan without location, but even without it, addition of timestamp check is enough to mark device as _verified_.

I also edited how flags are saved, if country code is not a real country code(spoofed), `null` flag is saved so it does not have to be fetched again. If fetching for real country code fails, it is probably connection issue and flag should be fetched again.
