### PR TITLE
ci: add asset upload to delivery

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -122,6 +122,7 @@ jobs:
           echo "keyAlias=${{ secrets.ANDROID_KEYSTORE_KEYALIAS }}" >> ./android/key.properties
           echo "storePassword=${{ secrets.ANDROID_KEYSTORE_PASS }}" >> ./android/key.properties
           echo "keyPassword=${{ secrets.ANDROID_KEYSTORE_PASS }}" >> ./android/key.properties
+          echo "${{ secrets.ANDROID_KEYSTORE_PASS }}" >> $HOME/keystore.pwd
           echo "storeFile=$HOME/android-keystore.jks" >> ./android/key.properties
       - name: Install Google Maps API key
         env:
@@ -174,6 +175,45 @@ jobs:
           env: ${{ env.DEPLOYMENT_ENV_NAME }}
           status: ${{ job.status }}
           env_url: ${{ inputs.url }}
+
+  upload-assets:
+    name: Convert & upload release assets
+    runs-on: ubuntu-latest
+    needs:
+      - release-version
+      - build-publish-ios
+      - build-publish-android
+    env:
+      RELEASED_VERSION: ${{ needs.release-version.outputs.version }}
+      ANDROID_KEYSTORE_PATH: android-keystore.jks
+      ANDROID_KEYSTORE_PASS_PATH: keystore.pwd
+      ANDROID_BUNDLE_PATH: android-app-bundle/bundle/release/app-release.aab
+      IOS_APP_PATH: ios-app-bundle/DroneScanner.ipa
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+      - name: Make Android keystore file
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 --decode > ${{ env.ANDROID_KEYSTORE_PATH }}
+          echo "${{ secrets.ANDROID_KEYSTORE_PASS }}" >>  ${{ env.ANDROID_KEYSTORE_PASS_PATH }}
+      - name: Unpack Android ABB bundle into universal APK
+        uses: dronetag/gha-shared/.github/actions/unpack-aab@master
+        id: unpack-aab
+        with:
+          bundle-path: ${{ env.ANDROID_BUNDLE_PATH }}
+          key-store-path: ${{ env.ANDROID_KEYSTORE_PATH }}
+          key-store-pass-path: ${{  env.ANDROID_KEYSTORE_PASS_PATH }}
+          key-store-alias: ${{ secrets.ANDROID_KEYSTORE_KEYALIAS }}
+      - name: Upload unpacked APK to release
+        run: gh release upload v${{ env.RELEASED_VERSION }} "${{ steps.unpack-aab.outputs.filename }}"
+      - name: Upload rest of the artifacts to release
+        run: |
+          gh release upload v${{ env.RELEASED_VERSION }} "${{ env.ANDROID_BUNDLE_PATH }}"
+          gh release upload v${{ env.RELEASED_VERSION }} "${{ env.IOS_APP_PATH }}"
 
   announce:
     name: Announce to Slack


### PR DESCRIPTION
Add missing upload of assets to Github release to delivery workflow.

Solves https://github.com/dronetag/drone-scanner/issues/77.

DT-3177