### PR TITLE
chore: flutter 3.22 deprecations and lints

### DIFF
--- a/lib/bloc/units_settings_cubit.dart
+++ b/lib/bloc/units_settings_cubit.dart
@@ -63,7 +63,7 @@ class UnitsSettingsCubit extends Cubit<UnitsSettingsState> {
 
   void updateUseConversionForExportSetting({required bool newValue}) async {
     await storage.setItem(_useConversionInExportKey, newValue);
-    emit(state.copyWith(useConversionInExports: newValue));
+    emit(state.copyWith(useConversionInExport: newValue));
   }
 
   UnitValue distanceDefaultToCurrent(UnitValue value) =>

--- a/lib/bloc/units_settings_state.dart
+++ b/lib/bloc/units_settings_state.dart
@@ -17,14 +17,14 @@ class UnitsSettingsState {
     String? distanceUnit,
     String? speedUnit,
     String? altitudeUnit,
-    bool? useConversionInExports,
+    bool? useConversionInExport,
   }) =>
       UnitsSettingsState(
         distanceUnit: distanceUnit ?? this.distanceUnit,
         speedUnit: speedUnit ?? this.speedUnit,
         altitudeUnit: altitudeUnit ?? this.altitudeUnit,
         useConversionInExport:
-            useConversionInExports ?? this.useConversionInExport,
+            useConversionInExport ?? this.useConversionInExport,
       );
 
   String get distanceSubUnit =>

--- a/lib/constants/theme.dart
+++ b/lib/constants/theme.dart
@@ -15,12 +15,10 @@ class AppTheme {
     secondary: Color.fromARGB(255, 22, 24, 25),
     secondaryContainer: AppColors.highlightBlue,
     surface: Colors.white,
-    background: Colors.white,
     error: AppColors.red,
     onPrimary: AppColors.dark,
     onSecondary: Colors.white,
     onSurface: AppColors.dark,
-    onBackground: AppColors.dark,
     onError: Colors.white,
     brightness: Brightness.light,
   );

--- a/lib/constants/theme_buttons.dart
+++ b/lib/constants/theme_buttons.dart
@@ -15,20 +15,20 @@ class ButtonsAppTheme {
 
   // -- Styles definitions
 
-  /// Resolves [MaterialStateProperty] simply for [normal] and [disabled]
+  /// Resolves [WidgetStateProperty] simply for [normal] and [disabled]
   /// states.
   /// FIXME: Not enough, resolve for the rest of states.
-  static MaterialStateProperty<T> _resolveWithDisabled<T>(
+  static WidgetStateProperty<T> _resolveWithDisabled<T>(
     T normal,
     T disabled,
   ) =>
-      MaterialStateProperty.resolveWith(
-        (states) => states.contains(MaterialState.disabled) ? disabled : normal,
+      WidgetStateProperty.resolveWith(
+        (states) => states.contains(WidgetState.disabled) ? disabled : normal,
       );
 
   static final baseStyle = ButtonStyle(
-    shape: MaterialStateProperty.all(defaultShape),
-    elevation: MaterialStateProperty.all(0.0),
+    shape: WidgetStateProperty.all(defaultShape),
+    elevation: WidgetStateProperty.all(0.0),
   );
 
   /// Default button style (gray with white text, outlined when disabled)
@@ -44,7 +44,7 @@ class ButtonsAppTheme {
 
   /// Default text button style
   static final textButtonStyle = baseStyle.copyWith(
-    backgroundColor: MaterialStateProperty.all(Colors.transparent),
+    backgroundColor: WidgetStateProperty.all(Colors.transparent),
     foregroundColor: _resolveWithDisabled(AppColors.dark, AppColors.lightGray),
   );
 
@@ -56,7 +56,7 @@ class ButtonsAppTheme {
       BorderSide.none,
       const BorderSide(color: AppColors.lightGray, width: 2.0),
     ),
-    shadowColor: MaterialStateProperty.all(AppColors.lightGray),
+    shadowColor: WidgetStateProperty.all(AppColors.lightGray),
     elevation: _resolveWithDisabled(8.0, 0),
   );
 
@@ -64,20 +64,20 @@ class ButtonsAppTheme {
   static final lightStyle = defaultStyle.copyWith(
     backgroundColor: _resolveWithDisabled(Colors.white, Colors.transparent),
     foregroundColor: _resolveWithDisabled(AppColors.dark, AppColors.lightGray),
-    overlayColor: MaterialStateProperty.all(AppColors.blue.withOpacity(0.1)),
+    overlayColor: WidgetStateProperty.all(AppColors.blue.withOpacity(0.1)),
     elevation: _resolveWithDisabled(buttonElevation, 0),
-    shadowColor: MaterialStateProperty.all(AppColors.lightGray),
+    shadowColor: WidgetStateProperty.all(AppColors.lightGray),
   );
 
   static final largeStyle = baseStyle.copyWith(
-    minimumSize: MaterialStateProperty.all(
+    minimumSize: WidgetStateProperty.all(
       const Size(Sizes.standard * 6, Sizes.standard * 6),
     ),
   );
 
   static final withoutPaddingStyle = baseStyle.copyWith(
-    padding: MaterialStateProperty.all(EdgeInsets.zero),
-    minimumSize: MaterialStateProperty.all(
+    padding: WidgetStateProperty.all(EdgeInsets.zero),
+    minimumSize: WidgetStateProperty.all(
       const Size(Sizes.standard * 6, Sizes.standard * 6),
     ),
   );
@@ -85,31 +85,31 @@ class ButtonsAppTheme {
   static final largeWithoutPaddingStyle = largeStyle.merge(withoutPaddingStyle);
 
   static final smallToolbarStyle = baseStyle.copyWith(
-    padding: MaterialStateProperty.all(EdgeInsets.zero),
-    minimumSize: MaterialStateProperty.all(const Size.square(32.0)),
+    padding: WidgetStateProperty.all(EdgeInsets.zero),
+    minimumSize: WidgetStateProperty.all(const Size.square(32.0)),
   );
 
   static final smallerStyle = baseStyle.copyWith(
-    padding: MaterialStateProperty.all(
+    padding: WidgetStateProperty.all(
       const EdgeInsets.symmetric(horizontal: Sizes.standard),
     ),
-    minimumSize: MaterialStateProperty.all(const Size.square(32.0)),
+    minimumSize: WidgetStateProperty.all(const Size.square(32.0)),
   );
 
   static final underlinedTextButtonStyle = textButtonStyle.copyWith(
-    textStyle: MaterialStateProperty.all(
+    textStyle: WidgetStateProperty.all(
       AppTheme.lightTheme.textTheme.bodyMedium!.copyWith(
         decoration: TextDecoration.underline,
       ),
     ),
-    foregroundColor: MaterialStateProperty.all(
+    foregroundColor: WidgetStateProperty.all(
       AppColors.lightGray,
     ),
   );
 
   static final negativeStyle = baseStyle.copyWith(
-    backgroundColor: MaterialStateProperty.all(AppColors.red),
-    foregroundColor: MaterialStateProperty.all(Colors.white),
+    backgroundColor: WidgetStateProperty.all(AppColors.red),
+    foregroundColor: WidgetStateProperty.all(Colors.white),
   );
 
   static final negativeWithoutPaddingStyle =
@@ -117,7 +117,7 @@ class ButtonsAppTheme {
 
   static final primaryTextStyle = textButtonStyle.copyWith(
     foregroundColor: _resolveWithDisabled(AppColors.blue, AppColors.lightGray),
-    textStyle: MaterialStateProperty.all(
+    textStyle: WidgetStateProperty.all(
       AppTheme.lightTheme.textTheme.bodyLarge!.copyWith(
         fontWeight: FontWeight.w700,
       ),
@@ -135,9 +135,9 @@ class ButtonsAppTheme {
 
   static final navBarButtonTheme = TextButtonThemeData(
     style: textButtonStyle.copyWith(
-      padding: MaterialStateProperty.all(EdgeInsets.zero),
+      padding: WidgetStateProperty.all(EdgeInsets.zero),
       textStyle:
-          MaterialStateProperty.all(AppTheme.lightTheme.textTheme.bodyLarge),
+          WidgetStateProperty.all(AppTheme.lightTheme.textTheme.bodyLarge),
       alignment: Alignment.centerRight,
     ),
   );

--- a/lib/widgets/app/custom_about_dialog.dart
+++ b/lib/widgets/app/custom_about_dialog.dart
@@ -14,7 +14,7 @@ class CustomAboutDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final buttonStyle = ButtonStyle(
-      backgroundColor: MaterialStateProperty.all<Color>(
+      backgroundColor: WidgetStateProperty.all<Color>(
         AppColors.preferencesButtonColor,
       ),
     );

--- a/lib/widgets/app/life_cycle_manager.dart
+++ b/lib/widgets/app/life_cycle_manager.dart
@@ -53,13 +53,13 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
             showcaseState.showcaseActive) {
           showcaseSub = context.read<ShowcaseCubit>().stream.listen((event) {
             if (event is ShowcaseStateInitialized && !event.showcaseActive) {
-              initPlatformState(context);
+              initPlatformState();
               showcaseSub?.cancel();
             }
           });
           return;
         } else {
-          initPlatformState(context);
+          initPlatformState();
         }
       },
     );
@@ -70,7 +70,7 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
     super.didChangeDependencies();
   }
 
-  Future<void> initPlatformState(BuildContext context) async {
+  Future<void> initPlatformState() async {
     if (Platform.isAndroid) {
       await _initPermissionsAndroid(context);
     } else if (Platform.isIOS) {
@@ -260,7 +260,7 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
             .setInternetAvailable(available: true);
       }
     } on SocketException catch (_) {
-      if (context.mounted) {
+      if (mounted) {
         await context
             .read<StandardsCubit>()
             .setInternetAvailable(available: false);

--- a/lib/widgets/help/help_page.dart
+++ b/lib/widgets/help/help_page.dart
@@ -123,7 +123,7 @@ class HelpPage extends StatelessWidget {
             ),
             ElevatedButton.icon(
               style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all<Color>(
+                backgroundColor: WidgetStateProperty.all<Color>(
                   AppColors.preferencesButtonColor,
                 ),
               ),

--- a/lib/widgets/mainpage/map_ui_google.dart
+++ b/lib/widgets/mainpage/map_ui_google.dart
@@ -173,7 +173,7 @@ class _MapUIGoogleState extends State<MapUIGoogle> with WidgetsBindingObserver {
             child: Container(
               width: MediaQuery.of(context).size.width,
               height: height,
-              color: Theme.of(context).colorScheme.background,
+              color: Theme.of(context).colorScheme.surface,
               child: const Center(
                 child: SizedBox(
                   width: 50,

--- a/lib/widgets/preferences/components/preferences_slider.dart
+++ b/lib/widgets/preferences/components/preferences_slider.dart
@@ -31,7 +31,7 @@ class _CleanPacksCheckboxState extends State<PreferencesSlider> {
             ? AppColors.preferencesButtonColor
             : AppColors.lightGray.withOpacity(0.75),
         activeColor: AppColors.highlightBlue,
-        trackColor: MaterialStateProperty.all<Color>(
+        trackColor: WidgetStateProperty.all<Color>(
           widget.enabled
               ? AppColors.lightGray
               : AppColors.lightGray.withOpacity(0.25),

--- a/lib/widgets/preferences/components/screen_sleep_checkbox.dart
+++ b/lib/widgets/preferences/components/screen_sleep_checkbox.dart
@@ -25,7 +25,7 @@ class _ScreenSleepCheckboxState extends State<ScreenSleepCheckbox> {
         materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
         inactiveThumbColor: AppColors.preferencesButtonColor,
         activeColor: AppColors.highlightBlue,
-        trackColor: MaterialStateProperty.all<Color>(
+        trackColor: WidgetStateProperty.all<Color>(
           AppColors.lightGray,
         ),
         value: _screenSleepDisabled,

--- a/lib/widgets/preferences/preferences_page.dart
+++ b/lib/widgets/preferences/preferences_page.dart
@@ -63,7 +63,7 @@ class PreferencesPage extends StatelessWidget {
                     'on your device and additional settings',
                 title: 'Preferences',
                 child: ColoredBox(
-                  color: Theme.of(context).colorScheme.background,
+                  color: Theme.of(context).colorScheme.surface,
                   child: Padding(
                     padding: isLandscape
                         ? EdgeInsets.only(
@@ -139,7 +139,7 @@ class PreferencesPage extends StatelessWidget {
     final wifiNanText = state.wifiNaN ? 'Fully supported' : 'Not supported';
     final maxAdvDataLenText = state.maxAdvDataLen.toString();
     final buttonStyle = ButtonStyle(
-      backgroundColor: MaterialStateProperty.all<Color>(
+      backgroundColor: WidgetStateProperty.all<Color>(
         AppColors.preferencesButtonColor,
       ),
     );

--- a/lib/widgets/preferences/proximity_alerts_page.dart
+++ b/lib/widgets/preferences/proximity_alerts_page.dart
@@ -48,7 +48,7 @@ class ProximityAlertsPage extends StatelessWidget {
                     'This page let you set proximity alerts for your device',
                 title: 'Proximity Alerts',
                 child: ColoredBox(
-                  color: Theme.of(context).colorScheme.background,
+                  color: Theme.of(context).colorScheme.surface,
                   child: Padding(
                     padding: isLandscape
                         ? EdgeInsets.only(
@@ -318,10 +318,10 @@ class ProximityAlertsPage extends StatelessWidget {
             context.read<SlidersCubit>().openSlider();
           },
           style: ButtonStyle(
-            backgroundColor: MaterialStateProperty.all<Color>(
+            backgroundColor: WidgetStateProperty.all<Color>(
               AppColors.preferencesButtonColor,
             ),
-            padding: MaterialStateProperty.all(
+            padding: WidgetStateProperty.all(
               const EdgeInsets.symmetric(
                 horizontal: Sizes.standard * 4,
                 vertical: Sizes.standard * 1.5,

--- a/lib/widgets/showcase/showcase_start_widget.dart
+++ b/lib/widgets/showcase/showcase_start_widget.dart
@@ -58,7 +58,7 @@ class ShowcaseStartWidget extends StatelessWidget {
           ElevatedButton(
             onPressed: startCallback,
             style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all<Color>(
+              backgroundColor: WidgetStateProperty.all<Color>(
                 AppColors.blue,
               ),
             ),
@@ -70,7 +70,7 @@ class ShowcaseStartWidget extends StatelessWidget {
           ElevatedButton(
             onPressed: skipCallback,
             style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all<Color>(
+              backgroundColor: WidgetStateProperty.all<Color>(
                 Colors.white,
               ),
             ),

--- a/lib/widgets/showcase/showcase_widget.dart
+++ b/lib/widgets/showcase/showcase_widget.dart
@@ -75,7 +75,7 @@ class ShowcaseWidget extends StatelessWidget {
             ElevatedButton(
               onPressed: nextCallback,
               style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all<Color>(
+                backgroundColor: WidgetStateProperty.all<Color>(
                   AppColors.blue,
                 ),
               ),
@@ -88,7 +88,7 @@ class ShowcaseWidget extends StatelessWidget {
             ElevatedButton(
               onPressed: skipCallback,
               style: ButtonStyle(
-                backgroundColor: MaterialStateProperty.all<Color>(
+                backgroundColor: WidgetStateProperty.all<Color>(
                   Colors.white,
                 ),
               ),

--- a/lib/widgets/sliders/aircraft/detail/set_as_mine_button.dart
+++ b/lib/widgets/sliders/aircraft/detail/set_as_mine_button.dart
@@ -47,10 +47,10 @@ class SetAsMineButton extends StatelessWidget {
         }
       },
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.all<Color>(
+        backgroundColor: WidgetStateProperty.all<Color>(
           proximityAlertsActive ? AppColors.green : Colors.white,
         ),
-        side: MaterialStateProperty.all<BorderSide>(
+        side: WidgetStateProperty.all<BorderSide>(
           BorderSide(
               width: 2.0,
               color: proximityAlertsActive ? Colors.white : AppColors.green),


### PR DESCRIPTION
Flutter 3.22 brings a new batch of lints and deprecations.

Lints:
- `Don't use 'BuildContext's across async gaps, guarded by an unrelated 'mounted' check` [use_build_context_synchronously](https://dart.dev/tools/linter-rules/use_build_context_synchronously).
This one is quite useful, we spammed `context.mounted` checks everywhere, but in stateful widget, `state.mounted` property should be checked instead

Deprecations:
- [Rename MaterialStateProperty to WidgetStateProperty](https://docs.flutter.dev/release/breaking-changes/material-state).
`MaterialState`, and its related APIs, have been moved out of the Material library and renamed to `WidgetState`.
- [new ColorScheme roles](https://docs.flutter.dev/release/breaking-changes/new-color-scheme-roles).
`background` should be replaced with `surface`, `onBackground` should be replaced with `onSurface`


DT-3124