### PR TITLE
feat: request background location permission

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -50,7 +50,7 @@
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Application needs Your location to show nearby aircraft.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>Application needs Your location to show nearby aircraft.</string>
+	<string>Application needs background location for Drone Radar feature.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Application needs Your location to show nearby aircraft.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/lib/widgets/preferences/preferences_page.dart
+++ b/lib/widgets/preferences/preferences_page.dart
@@ -322,6 +322,16 @@ class PreferencesPage extends StatelessWidget {
       Padding(
         padding: itemPadding,
         child: PreferencesField(
+          label: 'Background Location',
+          text: state.backgroundLocationEnabled ? 'Granted' : 'Not Granted',
+          color:
+              state.backgroundLocationEnabled ? AppColors.green : AppColors.red,
+          icon: state.backgroundLocationEnabled ? positiveIcon : negativeIcon,
+        ),
+      ),
+      Padding(
+        padding: itemPadding,
+        child: PreferencesField(
           label: 'Bluetooth',
           text: state.btEnabled ? 'Granted' : 'Not Granted',
           color: state.btEnabled ? AppColors.green : AppColors.red,


### PR DESCRIPTION
Add dialog about why background location is needed and request `locationAlways` permission. Background location is required for drone radar to work while the app is in the background.

Location permission should be requested gradually. First `location`, then if is enabled, request `locationAlways`.

On Android, there is no system dialog where the user can enable background location. The user has to select it in the app settings. Requesting `locationAlways` using permission handler navigates the user to settings. I added a dialog that explains why `locationAlways` is needed, selecting _'Continue'_ navigates to app settings.
This should be compliant with a [guide](https://developer.android.com/develop/sensors-and-location/location/permissions#background-dialog-target-android-11) on how to request background location on Android.

<img src="https://github.com/dronetag/drone-scanner/assets/15686037/d0ad79b0-da1d-4d99-adb3-eac8486e0af9" width="200" />

On iOS, it is bit different. Request returns 'granted' but this is some kind if intermediate state. System dialog is shown when app is minimized and tries to use location on background. There user can allow or deny. If user denies, than app will show the dialog with option to go to settings and change it.

<img width="200" alt="Screenshot 2024-07-06 at 21 46 04" src="https://github.com/dronetag/drone-scanner/assets/15686037/1ed0e053-5f23-487d-b84d-429202e29060">
