### PR TITLE
fix: local notifications on Android

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -98,7 +98,7 @@ SPEC CHECKSUMS:
   app_settings: 017320c6a680cdc94c799949d95b84cb69389ebc
   device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
+  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
   flutter_opendroneid: 92e28add32d6bf2b5705fdad0666657476de2e15
   google_maps_flutter_ios: f135b968a67c05679e0a53538e900b5c174b0d99
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d

--- a/lib/bloc/proximity_alerts_cubit.dart
+++ b/lib/bloc/proximity_alerts_cubit.dart
@@ -260,7 +260,6 @@ class ProximityAlertsCubit extends Cubit<ProximityAlertsState> {
                         '${foundAlerts.first.distance.toStringAsFixed(2)} '
                         'meters from your drone'
                     : '${foundAlerts.length} drones are flying close',
-                DateTime.now().millisecondsSinceEpoch + 1000,
               );
             }
           }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tz_data;
-import 'package:timezone/timezone.dart' as tz;
 
 class NotificationService {
   final _localNotificationsPlugin = FlutterLocalNotificationsPlugin();
@@ -16,13 +15,10 @@ class NotificationService {
 
   void addNotification(
     String title,
-    String body,
-    int endTime, {
+    String body, {
     String channel = 'default',
   }) async {
     tz_data.initializeTimeZones();
-    final scheduleTime =
-        tz.TZDateTime.fromMillisecondsSinceEpoch(tz.local, endTime);
     const iosDetail = DarwinNotificationDetails(
       presentAlert: false,
       presentBadge: false,
@@ -39,15 +35,6 @@ class NotificationService {
     );
     const id = 0;
 
-    await _localNotificationsPlugin.zonedSchedule(
-      id,
-      title,
-      body,
-      scheduleTime,
-      noticeDetail,
-      uiLocalNotificationDateInterpretation:
-          UILocalNotificationDateInterpretation.absoluteTime,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-    );
+    await _localNotificationsPlugin.show(id, title, body, noticeDetail);
   }
 }

--- a/lib/widgets/app/life_cycle_manager.dart
+++ b/lib/widgets/app/life_cycle_manager.dart
@@ -178,7 +178,7 @@ class _LifeCycleManagerState extends State<LifeCycleManager>
     final result = await flutterLocalNotificationsPlugin
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>()
-        ?.requestPermission();
+        ?.requestNotificationsPermission();
     standardsCubit.setNotificationsEnabled(enabled: result ?? false);
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,26 +266,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "5f79a1be5e9fef9ddd7f494532d31851399099f9defc21ebcb1ae4539e8a37f1"
+      sha256: c500d5d9e7e553f06b61877ca6b9c8b92c570a4c8db371038702e8ce57f8a50f
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.5"
+    version: "17.2.2"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
+      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0+1"
+    version: "4.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
+      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0+1"
+    version: "7.2.0"
   flutter_markdown:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_opendroneid: ^0.17.0
-  flutter_local_notifications: ^14.0.0
+  flutter_local_notifications: ^17.2.2
   another_flushbar: ^1.12.30
   google_maps_flutter: ^2.4.0
   location: ^5.0.3


### PR DESCRIPTION
Sending local notifications when app is in background failed with:

`PlatformException (PlatformException(exact_alarms_not_permitted, Exact alarms are not permitted))` on Android 14.

Bump [flutter_local_notifications](https://pub.dev/packages/flutter_local_notifications) package and use method `show()` instead of `zonedSchedule()` which requires `android.permission.USE_EXACT_ALARM`